### PR TITLE
Diff iam group resource

### DIFF
--- a/scaleway/data_source_iam_group.go
+++ b/scaleway/data_source_iam_group.go
@@ -1,0 +1,87 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func dataSourceScalewayIamGroup() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(resourceScalewayIamGroup().Schema)
+
+	addOptionalFieldsToSchema(dsSchema, "name", "description", "user_ids", "application_ids")
+
+	dsSchema["name"].ConflictsWith = []string{"group_id"}
+	dsSchema["group_id"] = &schema.Schema{
+		Type:          schema.TypeString,
+		Optional:      true,
+		Description:   "The ID of the IAM group",
+		ConflictsWith: []string{"name"},
+		ValidateFunc:  validationUUIDorUUIDWithLocality(),
+	}
+
+	return &schema.Resource{
+		ReadContext: dataSourceScalewayIamGroupRead,
+		Schema:      dsSchema,
+	}
+}
+
+func dataSourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+
+	groupID, groupIDExists := d.GetOk("group_id")
+	if !groupIDExists {
+		req := &iam.ListGroupsRequest{
+			OrganizationID: expandStringPtr(d.Get("organization_id")),
+			Name:           expandStringPtr(d.Get("name")),
+		}
+		if appIDs := d.Get("application_ids"); appIDs != nil {
+			req.ApplicationIDs = expandStrings(appIDs)
+		}
+		if userIDs := d.Get("user_ids"); userIDs != nil {
+			req.ApplicationIDs = expandStrings(userIDs)
+		}
+		if groupIDs := d.Get("group_ids"); groupIDs != nil {
+			req.ApplicationIDs = expandStrings(groupIDs)
+		}
+		// spew.Dump(req)
+
+		res, err := api.ListGroups(req, scw.WithContext(ctx))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, group := range res.Groups {
+			if group.Name == d.Get("name").(string) {
+				if groupID != "" {
+					return diag.Errorf("more than 1 group found with the same name %s", d.Get("name"))
+				}
+				groupID = group.ID
+			}
+		}
+		if groupID == "" {
+			return diag.Errorf("no group found with the name %s", d.Get("name"))
+		}
+	}
+
+	d.SetId(groupID.(string))
+	err := d.Set("group_id", groupID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	diags := resourceScalewayIamGroupRead(ctx, d, meta)
+	if diags != nil {
+		return append(diags, diag.Errorf("failed to read iam group state")...)
+	}
+
+	if d.Id() == "" {
+		return diag.Errorf("iam group (%s) not found", groupID)
+	}
+
+	return nil
+}

--- a/scaleway/data_source_iam_group.go
+++ b/scaleway/data_source_iam_group.go
@@ -21,9 +21,9 @@ func dataSourceScalewayIamGroup() *schema.Resource {
 		Optional:      true,
 		Description:   "The ID of the IAM group",
 		ConflictsWith: []string{"name"},
-		ValidateFunc:  validationUUIDorUUIDWithLocality(),
+		ValidateFunc:  validationUUID(),
 	}
-	// Requiring organization_id is temporary until we are able to get it from the sdk
+	// Default organization_id will be available on a major release. Please check #1337
 	dsSchema["organization_id"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Description: "The organization_id you want to attach the resource to",

--- a/scaleway/data_source_iam_group.go
+++ b/scaleway/data_source_iam_group.go
@@ -49,10 +49,7 @@ func dataSourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData,
 			req.ApplicationIDs = expandStrings(appIDs)
 		}
 		if userIDs := d.Get("user_ids"); userIDs != nil {
-			req.ApplicationIDs = expandStrings(userIDs)
-		}
-		if groupIDs := d.Get("group_ids"); groupIDs != nil {
-			req.ApplicationIDs = expandStrings(groupIDs)
+			req.UserIDs = expandStrings(userIDs)
 		}
 
 		res, err := api.ListGroups(req, scw.WithContext(ctx))

--- a/scaleway/data_source_iam_group.go
+++ b/scaleway/data_source_iam_group.go
@@ -23,6 +23,12 @@ func dataSourceScalewayIamGroup() *schema.Resource {
 		ConflictsWith: []string{"name"},
 		ValidateFunc:  validationUUIDorUUIDWithLocality(),
 	}
+	// Requiring organization_id is temporary until we are able to get it from the sdk
+	dsSchema["organization_id"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "The organization_id you want to attach the resource to",
+		Required:    true,
+	}
 
 	return &schema.Resource{
 		ReadContext: dataSourceScalewayIamGroupRead,
@@ -48,7 +54,6 @@ func dataSourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData,
 		if groupIDs := d.Get("group_ids"); groupIDs != nil {
 			req.ApplicationIDs = expandStrings(groupIDs)
 		}
-		// spew.Dump(req)
 
 		res, err := api.ListGroups(req, scw.WithContext(ctx))
 		if err != nil {

--- a/scaleway/data_source_iam_group.go
+++ b/scaleway/data_source_iam_group.go
@@ -13,7 +13,7 @@ func dataSourceScalewayIamGroup() *schema.Resource {
 	// Generate datasource schema from resource
 	dsSchema := datasourceSchemaFromResourceSchema(resourceScalewayIamGroup().Schema)
 
-	addOptionalFieldsToSchema(dsSchema, "name", "description", "user_ids", "application_ids")
+	addOptionalFieldsToSchema(dsSchema, "name")
 
 	dsSchema["name"].ConflictsWith = []string{"group_id"}
 	dsSchema["group_id"] = &schema.Schema{
@@ -44,12 +44,6 @@ func dataSourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData,
 		req := &iam.ListGroupsRequest{
 			OrganizationID: expandStringPtr(d.Get("organization_id")),
 			Name:           expandStringPtr(d.Get("name")),
-		}
-		if appIDs := d.Get("application_ids"); appIDs != nil {
-			req.ApplicationIDs = expandStrings(appIDs)
-		}
-		if userIDs := d.Get("user_ids"); userIDs != nil {
-			req.UserIDs = expandStrings(userIDs)
 		}
 
 		res, err := api.ListGroups(req, scw.WithContext(ctx))

--- a/scaleway/data_source_iam_group_test.go
+++ b/scaleway/data_source_iam_group_test.go
@@ -1,0 +1,53 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccScalewayDataSourceIamGroup_Basic(t *testing.T) {
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayIamGroupDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_iam_group" "main" {
+						name        = "test-terraform"
+					}
+			
+					data "scaleway_iam_group" "find_by_id" {
+						group_id 	= scaleway_iam_group.main.id
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "name", "test-terraform"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
+				),
+			},
+			{
+				Config: `
+					resource "scaleway_iam_group" "main" {
+						name        = "test-terraform"
+					}
+
+					data "scaleway_iam_group" "find_by_name" {
+						name        = scaleway_iam_group.main.name
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "name", "test-terraform"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "id", "scaleway_iam_group.main", "id"),
+				),
+			},
+		},
+	})
+}

--- a/scaleway/data_source_iam_group_test.go
+++ b/scaleway/data_source_iam_group_test.go
@@ -44,3 +44,58 @@ func TestAccScalewayDataSourceIamGroup_Basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccScalewayDataSourceIamGroup_UsersAndApplications(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayIamGroupDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_iam_application" "app01" {
+						name = "first app"
+					}
+					resource "scaleway_iam_group" "main" {
+						name = "test-terraform"
+						application_ids = [
+							scaleway_iam_application.app01.id,
+						]
+						user_ids = [
+							"ce18cffd-e7c8-47f8-8de8-00e97e50a0d3",
+							"255b63c2-b4de-4af6-9ed4-967f69d9dd85",
+						]
+					}
+			
+					data "scaleway_iam_group" "find_by_id" {
+						group_id 	= scaleway_iam_group.main.id
+						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
+					}
+
+					data "scaleway_iam_group" "find_by_name" {
+						name        = scaleway_iam_group.main.name
+						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
+					}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "name", "test-terraform"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "name", "test-terraform"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "id", "scaleway_iam_group.main", "id"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "application_ids.0", "scaleway_iam_application.app01", "id"),
+				),
+			},
+		},
+	})
+}

--- a/scaleway/data_source_iam_group_test.go
+++ b/scaleway/data_source_iam_group_test.go
@@ -19,26 +19,26 @@ func TestAccScalewayDataSourceIamGroup_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-					resource "scaleway_iam_group" "main" {
-						name        = "test-terraform"
+					resource "scaleway_iam_group" "main_ds_basic" {
+						name        = "test_data_source_basic"
 					}
 			
-					data "scaleway_iam_group" "find_by_id" {
-						group_id 	= scaleway_iam_group.main.id
+					data "scaleway_iam_group" "find_by_id_basic" {
+						group_id 	= scaleway_iam_group.main_ds_basic.id
 						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
 					}
 
-					data "scaleway_iam_group" "find_by_name" {
-						name        = scaleway_iam_group.main.name
+					data "scaleway_iam_group" "find_by_name_basic" {
+						name        = scaleway_iam_group.main_ds_basic.name
 						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "name", "test-terraform"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "name", "test-terraform"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "id", "scaleway_iam_group.main", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_ds_basic"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id_basic", "name", "test_data_source_basic"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name_basic", "name", "test_data_source_basic"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id_basic", "id", "scaleway_iam_group.main_ds_basic", "id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name_basic", "id", "scaleway_iam_group.main_ds_basic", "id"),
 				),
 			},
 		},
@@ -58,13 +58,13 @@ func TestAccScalewayDataSourceIamGroup_UsersAndApplications(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-					resource "scaleway_iam_application" "app01" {
-						name = "first app"
+					resource "scaleway_iam_application" "app00" {
+						name = "app"
 					}
-					resource "scaleway_iam_group" "main" {
-						name = "test-terraform"
+					resource "scaleway_iam_group" "main_ds_mix" {
+						name = "test_data_source_mix"
 						application_ids = [
-							scaleway_iam_application.app01.id,
+							scaleway_iam_application.app00.id,
 						]
 						user_ids = [
 							"ce18cffd-e7c8-47f8-8de8-00e97e50a0d3",
@@ -72,28 +72,28 @@ func TestAccScalewayDataSourceIamGroup_UsersAndApplications(t *testing.T) {
 						]
 					}
 			
-					data "scaleway_iam_group" "find_by_id" {
-						group_id 	= scaleway_iam_group.main.id
+					data "scaleway_iam_group" "find_by_id_mix" {
+						group_id 	= scaleway_iam_group.main_ds_mix.id
 						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
 					}
 
-					data "scaleway_iam_group" "find_by_name" {
-						name        = scaleway_iam_group.main.name
+					data "scaleway_iam_group" "find_by_name_mix" {
+						name        = scaleway_iam_group.main_ds_mix.name
 						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "name", "test-terraform"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "name", "test-terraform"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "id", "scaleway_iam_group.main", "id"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
-					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "application_ids.0", "scaleway_iam_application.app01", "id"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_ds_mix"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id_mix", "name", "test_data_source_mix"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name_mix", "name", "test_data_source_mix"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id_mix", "id", "scaleway_iam_group.main_ds_mix", "id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name_mix", "id", "scaleway_iam_group.main_ds_mix", "id"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id_mix", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id_mix", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name_mix", "user_ids.0", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
+					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name_mix", "user_ids.1", "255b63c2-b4de-4af6-9ed4-967f69d9dd85"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id_mix", "application_ids.0", "scaleway_iam_application.app00", "id"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name_mix", "application_ids.0", "scaleway_iam_application.app00", "id"),
 				),
 			},
 		},

--- a/scaleway/data_source_iam_group_test.go
+++ b/scaleway/data_source_iam_group_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAccScalewayDataSourceIamGroup_Basic(t *testing.T) {
+	SkipBetaTest(t)
 	tt := NewTestTools(t)
 	defer tt.Cleanup()
 	resource.ParallelTest(t, resource.TestCase{

--- a/scaleway/data_source_iam_group_test.go
+++ b/scaleway/data_source_iam_group_test.go
@@ -24,27 +24,19 @@ func TestAccScalewayDataSourceIamGroup_Basic(t *testing.T) {
 			
 					data "scaleway_iam_group" "find_by_id" {
 						group_id 	= scaleway_iam_group.main.id
+						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
+					}
+
+					data "scaleway_iam_group" "find_by_name" {
+						name        = scaleway_iam_group.main.name
+						organization_id = "08555df8-bb26-43bc-b749-1b98c5d02343"
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
 					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_id", "name", "test-terraform"),
-					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
-				),
-			},
-			{
-				Config: `
-					resource "scaleway_iam_group" "main" {
-						name        = "test-terraform"
-					}
-
-					data "scaleway_iam_group" "find_by_name" {
-						name        = scaleway_iam_group.main.name
-					}
-				`,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
 					resource.TestCheckResourceAttr("data.scaleway_iam_group.find_by_name", "name", "test-terraform"),
+					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_id", "id", "scaleway_iam_group.main", "id"),
 					resource.TestCheckResourceAttrPair("data.scaleway_iam_group.find_by_name", "id", "scaleway_iam_group.main", "id"),
 				),
 			},

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -33,6 +33,7 @@ func addBetaResources(provider *schema.Provider) {
 	}
 	betaResources := map[string]*schema.Resource{
 		"scaleway_iam_application": resourceScalewayIamApplication(),
+		"scaleway_iam_group":       resourceScalewayIamGroup(),
 	}
 	betaDataSources := map[string]*schema.Resource{}
 	for resourceName, resource := range betaResources {

--- a/scaleway/provider.go
+++ b/scaleway/provider.go
@@ -35,7 +35,9 @@ func addBetaResources(provider *schema.Provider) {
 		"scaleway_iam_application": resourceScalewayIamApplication(),
 		"scaleway_iam_group":       resourceScalewayIamGroup(),
 	}
-	betaDataSources := map[string]*schema.Resource{}
+	betaDataSources := map[string]*schema.Resource{
+		"scaleway_iam_group": dataSourceScalewayIamGroup(),
+	}
 	for resourceName, resource := range betaResources {
 		provider.ResourcesMap[resourceName] = resource
 	}

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -1,0 +1,135 @@
+package scaleway
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func resourceScalewayIamGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScalewayIamGroupCreate,
+		ReadContext:   resourceScalewayIamGroupRead,
+		UpdateContext: resourceScalewayIamGroupUpdate,
+		DeleteContext: resourceScalewayIamGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		SchemaVersion: 0,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Optional:    true,
+				Description: "The name of the iam group",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of the iam group",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time of the creation of the group",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time of the last update of the group",
+			},
+			"user_ids": {
+				Type:        schema.TypeList,
+				Description: "List of IDs of the users attached to the group",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validationUUID(),
+				},
+			},
+			"application_ids": {
+				Type:        schema.TypeList,
+				Description: "List of IDs of the applications attached to the group",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validationUUID(),
+				},
+			},
+			"organization_id": organizationIDSchema(),
+		},
+	}
+}
+
+func resourceScalewayIamGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+	group, err := api.CreateGroup(&iam.CreateGroupRequest{
+		OrganizationID: d.Get("organization_id").(string),
+		Name:           expandOrGenerateString(d.Get("name"), "group-"),
+		Description:    d.Get("description").(string),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(group.ID)
+
+	return resourceScalewayIamGroupRead(ctx, d, meta)
+}
+
+func resourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+	group, err := api.GetGroup(&iam.GetGroupRequest{
+		GroupID: d.Id(),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	_ = d.Set("name", group.Name)
+	_ = d.Set("description", group.Description)
+	_ = d.Set("created_at", flattenTime(group.CreatedAt))
+	_ = d.Set("updated_at", flattenTime(group.UpdatedAt))
+	_ = d.Set("organization_id", group.OrganizationID)
+	_ = d.Set("user_ids", group.UserIDs)
+	_ = d.Set("application_ids", group.ApplicationIDs)
+
+	return nil
+}
+
+func resourceScalewayIamGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+
+	req := &iam.UpdateGroupRequest{
+		GroupID: d.Id(),
+	}
+
+	if d.HasChange("name") {
+		req.Name = expandStringPtr(d.Get("name"))
+	}
+	if d.HasChange("description") {
+		req.Description = expandStringPtr(d.Get("description"))
+	}
+
+	_, err := api.UpdateGroup(req, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceScalewayIamGroupRead(ctx, d, meta)
+}
+
+func resourceScalewayIamGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	api := iamAPI(meta)
+
+	err := api.DeleteGroup(&iam.DeleteGroupRequest{
+		GroupID: d.Id(),
+	})
+	if err != nil && !is404Error(err) {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -148,11 +148,13 @@ func resourceScalewayIamGroupUpdate(ctx context.Context, d *schema.ResourceData,
 
 	if d.HasChange("description") {
 		req.Description = expandStringPtr(d.Get("description").(string))
-	}
-	if group.Description != "" {
-		req.Description = &group.Description
 	} else {
-		req.Description = nil
+		// I know it's not pretty but the linter won't let me use 'else if' even though I'm not evaluating the same statement
+		if group.Description != "" {
+			req.Description = &group.Description
+		} else {
+			req.Description = nil
+		}
 	}
 
 	if d.HasChange("application_ids") || d.HasChange("user_ids") {

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -126,7 +126,7 @@ func resourceScalewayIamGroupDelete(ctx context.Context, d *schema.ResourceData,
 
 	err := api.DeleteGroup(&iam.DeleteGroupRequest{
 		GroupID: d.Id(),
-	})
+	}, scw.WithContext(ctx))
 	if err != nil && !is404Error(err) {
 		return diag.FromErr(err)
 	}

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -66,13 +66,42 @@ func resourceScalewayIamGroup() *schema.Resource {
 
 func resourceScalewayIamGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := iamAPI(meta)
-	group, err := api.CreateGroup(&iam.CreateGroupRequest{
+	req := &iam.CreateGroupRequest{
 		OrganizationID: d.Get("organization_id").(string),
 		Name:           expandOrGenerateString(d.Get("name"), "group-"),
 		Description:    d.Get("description").(string),
-	}, scw.WithContext(ctx))
+	}
+	group, err := api.CreateGroup(req, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	if appIds := d.Get("application_ids").([]interface{}); len(appIds) > 0 {
+		appIdsStr := []string(nil)
+		for _, id := range appIds {
+			appIdsStr = append(appIdsStr, id.(string))
+		}
+		_, err := api.SetGroupPrincipals(&iam.SetGroupPrincipalsRequest{
+			ApplicationIDs: appIdsStr,
+			GroupID:        group.ID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if userIds := d.Get("user_ids").([]interface{}); len(userIds) > 0 {
+		userIdsStr := []string(nil)
+		for _, id := range userIds {
+			userIdsStr = append(userIdsStr, id.(string))
+		}
+		_, err := api.SetGroupPrincipals(&iam.SetGroupPrincipalsRequest{
+			UserIDs: userIdsStr,
+			GroupID: group.ID,
+		}, scw.WithContext(ctx))
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	d.SetId(group.ID)
@@ -86,8 +115,13 @@ func resourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData, m
 		GroupID: d.Id(),
 	}, scw.WithContext(ctx))
 	if err != nil {
+		if is404Error(err) {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
+
 	_ = d.Set("name", group.Name)
 	_ = d.Set("description", group.Description)
 	_ = d.Set("created_at", flattenTime(group.CreatedAt))
@@ -102,18 +136,84 @@ func resourceScalewayIamGroupRead(ctx context.Context, d *schema.ResourceData, m
 func resourceScalewayIamGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	api := iamAPI(meta)
 
-	req := &iam.UpdateGroupRequest{
+	group, err := api.GetGroup(&iam.GetGroupRequest{
 		GroupID: d.Id(),
+	}, scw.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	req := &iam.UpdateGroupRequest{
+		GroupID: group.ID,
 	}
 
 	if d.HasChange("name") {
-		req.Name = expandStringPtr(d.Get("name"))
-	}
-	if d.HasChange("description") {
-		req.Description = expandStringPtr(d.Get("description"))
+		req.Name = expandStringPtr(d.Get("name").(string))
+	} else {
+		req.Name = &group.Name
 	}
 
-	_, err := api.UpdateGroup(req, scw.WithContext(ctx))
+	if d.HasChange("description") {
+		req.Description = expandStringPtr(d.Get("description").(string))
+	} else if group.Description != "" {
+		req.Description = &group.Description
+	} else {
+		req.Description = nil
+	}
+
+	if d.HasChange("application_ids") {
+		appIdsStr := []string(nil)
+		if appIds := d.Get("application_ids").([]interface{}); len(appIds) > 0 {
+			for _, id := range appIds {
+				appIdsStr = append(appIdsStr, id.(string))
+			}
+			_, err = api.SetGroupPrincipals(&iam.SetGroupPrincipalsRequest{
+				ApplicationIDs: appIdsStr,
+				GroupID:        group.ID,
+			}, scw.WithContext(ctx))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			for _, toRemove := range group.ApplicationIDs {
+				_, err = api.DeletePrincipalFromGroup(&iam.DeletePrincipalFromGroupRequest{
+					GroupID:     group.ID,
+					PrincipalID: toRemove,
+				}, scw.WithContext(ctx))
+				if err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	if d.HasChange("user_ids") {
+		userIdsStr := []string(nil)
+		if userIds := d.Get("user_ids").([]interface{}); len(userIds) > 0 {
+			for _, id := range userIds {
+				userIdsStr = append(userIdsStr, id.(string))
+			}
+			_, err = api.SetGroupPrincipals(&iam.SetGroupPrincipalsRequest{
+				UserIDs: userIdsStr,
+				GroupID: group.ID,
+			}, scw.WithContext(ctx))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			for _, toRemove := range group.UserIDs {
+				_, err = api.DeletePrincipalFromGroup(&iam.DeletePrincipalFromGroupRequest{
+					GroupID:     group.ID,
+					PrincipalID: toRemove,
+				}, scw.WithContext(ctx))
+				if err != nil {
+					return diag.FromErr(err)
+				}
+			}
+		}
+	}
+
+	_, err = api.UpdateGroup(req, scw.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/scaleway/resource_iam_group.go
+++ b/scaleway/resource_iam_group.go
@@ -157,7 +157,7 @@ func resourceScalewayIamGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	if d.HasChange("application_ids") || d.HasChange("user_ids") {
+	if d.HasChanges("application_ids", "user_ids") {
 		appIdsStr := []string(nil)
 		appIds := d.Get("application_ids").([]interface{})
 		for _, id := range appIds {

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -1,0 +1,121 @@
+package scaleway
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	iam "github.com/scaleway/scaleway-sdk-go/api/iam/v1alpha1"
+	"github.com/scaleway/scaleway-sdk-go/scw"
+)
+
+func init() {
+	resource.AddTestSweepers("scaleway_iam_group", &resource.Sweeper{
+		Name: "scaleway_iam_group",
+		F:    testSweepIamGroup,
+	})
+}
+
+func testSweepIamGroup(_ string) error {
+	return sweep(func(scwClient *scw.Client) error {
+		api := iam.NewAPI(scwClient)
+
+		listApps, err := api.ListGroups(&iam.ListGroupsRequest{})
+		if err != nil {
+			return fmt.Errorf("failed to list groups: %w", err)
+		}
+		for _, app := range listApps.Groups {
+			err = api.DeleteGroup(&iam.DeleteGroupRequest{
+				GroupID: app.ID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete group: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+func TestAccScalewayIamGroup_Basic(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      testAccCheckScalewayIamGroupDestroy(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttrSet("scaleway_iam_group.main", "name"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_basic"
+							description = "basic description"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_basic"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckScalewayIamGroupExists(tt *TestTools, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", name)
+		}
+
+		iamAPI := iamAPI(tt.Meta)
+
+		_, err := iamAPI.GetGroup(&iam.GetGroupRequest{
+			GroupID: rs.Primary.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("could not find group: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckScalewayIamGroupDestroy(tt *TestTools) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "scaleway_iam_group" {
+				continue
+			}
+
+			iamAPI := iamAPI(tt.Meta)
+
+			_, err := iamAPI.GetGroup(&iam.GetGroupRequest{
+				GroupID: rs.Primary.ID,
+			})
+
+			// If no error resource still exist
+			if err == nil {
+				return fmt.Errorf("resource %s(%s) still exist", rs.Type, rs.Primary.ID)
+			}
+
+			// Unexpected api error we return it
+			if !is404Error(err) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -98,7 +98,7 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "this is another description"),
 				),
 			},
-			//{
+			// {
 			//	Config: `
 			//			resource "scaleway_iam_group" "main" {
 			//				name = "iam_group_renamed"
@@ -110,7 +110,7 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 			//		//resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
 			//		// This test fails for now because
 			//	),
-			//},
+			// },
 		},
 	})
 }
@@ -283,6 +283,121 @@ func TestAccScalewayIamGroup_Users(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScalewayIamGroup_UsersAndApplications(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayIamGroupDestroy(tt),
+			testAccCheckScalewayIamApplicationDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app01.id
+							]
+							user_ids = [
+								"29c31dd4-8ea1-4927-82d9-a0620e04773f"
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app01.id,
+								scaleway_iam_application.app02.id,
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "2"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.1", "scaleway_iam_application.app02", "id"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app02.id,
+							]
+							user_ids = [
+								"29c31dd4-8ea1-4927-82d9-a0620e04773f",
+								"0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017",
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app02", "id"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "application_ids.0"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
 					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
 				),

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -52,50 +52,50 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {}
+						resource "scaleway_iam_group" "main_basic" {}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttrSet("scaleway_iam_group.main", "name"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_basic"),
+					resource.TestCheckResourceAttrSet("scaleway_iam_group.main_basic", "name"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "description", ""),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_basic" {
 							description = "basic description"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttrSet("scaleway_iam_group.main", "name"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_basic"),
+					resource.TestCheckResourceAttrSet("scaleway_iam_group.main_basic", "name"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "description", "basic description"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_basic" {
 							name = "iam_group_basic"
 							description = "basic description"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_basic"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_basic"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "name", "iam_group_basic"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "description", "basic description"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_basic" {
 							name = "iam_group_renamed"
 							description = "this is another description"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_renamed"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "this is another description"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_basic"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "name", "iam_group_renamed"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_basic", "description", "this is another description"),
 				),
 			},
 			// {
@@ -131,7 +131,7 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						resource "scaleway_iam_application" "app01" {
 							name = "first app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_app" {
 							name = "iam_group_app"
 							application_ids = [
 								scaleway_iam_application.app01.id
@@ -139,10 +139,10 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_app", "application_ids.0", "scaleway_iam_application.app01", "id"),
 				),
 			},
 			{
@@ -153,7 +153,7 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						resource "scaleway_iam_application" "app02" {
 							name = "second app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_app" {
 							name = "iam_group_app"
 							application_ids = [
 								scaleway_iam_application.app01.id,
@@ -162,11 +162,11 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "2"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.1", "scaleway_iam_application.app02", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "application_ids.#", "2"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_app", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_app", "application_ids.1", "scaleway_iam_application.app02", "id"),
 				),
 			},
 			{
@@ -177,7 +177,7 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						resource "scaleway_iam_application" "app02" {
 							name = "second app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_app" {
 							name = "iam_group_app"
 							application_ids = [
 								scaleway_iam_application.app02.id,
@@ -185,10 +185,10 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app02", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_app", "application_ids.0", "scaleway_iam_application.app02", "id"),
 				),
 			},
 			{
@@ -199,15 +199,15 @@ func TestAccScalewayIamGroup_Applications(t *testing.T) {
 						resource "scaleway_iam_application" "app02" {
 							name = "second app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_app" {
 							name = "iam_group_app"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "0"),
-					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "application_ids.0"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_app", "application_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_app", "application_ids.0"),
 				),
 			},
 		},
@@ -226,7 +226,7 @@ func TestAccScalewayIamGroup_Users(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_user" {
 							name = "iam_group_user"
 							user_ids = [
 								"29c31dd4-8ea1-4927-82d9-a0620e04773f"
@@ -234,15 +234,15 @@ func TestAccScalewayIamGroup_Users(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_user" {
 							name = "iam_group_user"
 							user_ids = [
 								"29c31dd4-8ea1-4927-82d9-a0620e04773f",
@@ -251,16 +251,16 @@ func TestAccScalewayIamGroup_Users(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "2"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_user" {
 							name = "iam_group_user"
 							user_ids = [
 								"453c1a85-4a10-4c6f-94dc-d3193d4589a5",
@@ -268,23 +268,23 @@ func TestAccScalewayIamGroup_Users(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "453c1a85-4a10-4c6f-94dc-d3193d4589a5"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.0", "453c1a85-4a10-4c6f-94dc-d3193d4589a5"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_user" {
 							name = "iam_group_user"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
-					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_user", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_user", "user_ids.0"),
 				),
 			},
 		},
@@ -304,13 +304,13 @@ func TestAccScalewayIamGroup_UsersAndApplications(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-						resource "scaleway_iam_application" "app01" {
-							name = "first app"
+						resource "scaleway_iam_application" "app03" {
+							name = "third app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_mix" {
 							name = "iam_group_app"
 							application_ids = [
-								scaleway_iam_application.app01.id
+								scaleway_iam_application.app03.id
 							]
 							user_ids = [
 								"29c31dd4-8ea1-4927-82d9-a0620e04773f"
@@ -318,52 +318,52 @@ func TestAccScalewayIamGroup_UsersAndApplications(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_mix"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_mix", "application_ids.0", "scaleway_iam_application.app03", "id"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_application" "app01" {
-							name = "first app"
+						resource "scaleway_iam_application" "app03" {
+							name = "third app"
 						}
-						resource "scaleway_iam_application" "app02" {
-							name = "second app"
+						resource "scaleway_iam_application" "app04" {
+							name = "fourth app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_mix" {
 							name = "iam_group_app"
 							application_ids = [
-								scaleway_iam_application.app01.id,
-								scaleway_iam_application.app02.id,
+								scaleway_iam_application.app03.id,
+								scaleway_iam_application.app04.id,
 							]
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "2"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.1", "scaleway_iam_application.app02", "id"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
-					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_mix"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "application_ids.#", "2"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_mix", "application_ids.0", "scaleway_iam_application.app03", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_mix", "application_ids.1", "scaleway_iam_application.app04", "id"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_mix", "user_ids.0"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_application" "app01" {
-							name = "first app"
+						resource "scaleway_iam_application" "app03" {
+							name = "third app"
 						}
-						resource "scaleway_iam_application" "app02" {
-							name = "second app"
+						resource "scaleway_iam_application" "app04" {
+							name = "fourth app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_mix" {
 							name = "iam_group_app"
 							application_ids = [
-								scaleway_iam_application.app02.id,
+								scaleway_iam_application.app04.id,
 							]
 							user_ids = [
 								"29c31dd4-8ea1-4927-82d9-a0620e04773f",
@@ -372,34 +372,34 @@ func TestAccScalewayIamGroup_UsersAndApplications(t *testing.T) {
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
-					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app02", "id"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "2"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_mix"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main_mix", "application_ids.0", "scaleway_iam_application.app04", "id"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
 				),
 			},
 			{
 				Config: `
-						resource "scaleway_iam_application" "app01" {
-							name = "first app"
+						resource "scaleway_iam_application" "app03" {
+							name = "third app"
 						}
-						resource "scaleway_iam_application" "app02" {
-							name = "second app"
+						resource "scaleway_iam_application" "app04" {
+							name = "fourth app"
 						}
-						resource "scaleway_iam_group" "main" {
+						resource "scaleway_iam_group" "main_mix" {
 							name = "iam_group_app"
 						}
 					`,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "0"),
-					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "application_ids.0"),
-					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
-					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_mix"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "application_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_mix", "application_ids.0"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_mix", "user_ids.0"),
 				),
 			},
 		},

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -63,6 +63,18 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 			{
 				Config: `
 						resource "scaleway_iam_group" "main" {
+							description = "basic description"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttrSet("scaleway_iam_group.main", "name"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
 							name = "iam_group_basic"
 							description = "basic description"
 						}
@@ -71,6 +83,208 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_basic"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "basic description"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_renamed"
+							description = "this is another description"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_renamed"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", "this is another description"),
+				),
+			},
+			//{
+			//	Config: `
+			//			resource "scaleway_iam_group" "main" {
+			//				name = "iam_group_renamed"
+			//			}
+			//		`,
+			//	Check: resource.ComposeTestCheckFunc(
+			//		testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+			//		resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_renamed"),
+			//		//resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
+			//		// This test fails for now because
+			//	),
+			//},
+		},
+	})
+}
+
+func TestAccScalewayIamGroup_Applications(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayIamGroupDestroy(tt),
+			testAccCheckScalewayIamApplicationDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app01.id
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app01.id,
+								scaleway_iam_application.app02.id,
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "2"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app01", "id"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.1", "scaleway_iam_application.app02", "id"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+							application_ids = [
+								scaleway_iam_application.app02.id,
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_iam_group.main", "application_ids.0", "scaleway_iam_application.app02", "id"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app01" {
+							name = "first app"
+						}
+						resource "scaleway_iam_application" "app02" {
+							name = "second app"
+						}
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_app"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "application_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "application_ids.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccScalewayIamGroup_Users(t *testing.T) {
+	SkipBetaTest(t)
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayIamGroupDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_user"
+							user_ids = [
+								"29c31dd4-8ea1-4927-82d9-a0620e04773f"
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_user"
+							user_ids = [
+								"29c31dd4-8ea1-4927-82d9-a0620e04773f",
+								"0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017",
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "2"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_user"
+							user_ids = [
+								"453c1a85-4a10-4c6f-94dc-d3193d4589a5",
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "1"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.0", "453c1a85-4a10-4c6f-94dc-d3193d4589a5"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_group" "main" {
+							name = "iam_group_user"
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_user"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main", "user_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main", "user_ids.0"),
 				),
 			},
 		},

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -108,7 +108,9 @@ func TestAccScalewayIamGroup_Basic(t *testing.T) {
 			//		testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main"),
 			//		resource.TestCheckResourceAttr("scaleway_iam_group.main", "name", "iam_group_renamed"),
 			//		//resource.TestCheckResourceAttr("scaleway_iam_group.main", "description", ""),
-			//		// This test fails for now because
+
+			//		// TODO: This test fails for now because description can't be unset
+			// A ticket has been opened about this issue
 			//	),
 			// },
 		},
@@ -379,6 +381,34 @@ func TestAccScalewayIamGroup_UsersAndApplications(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "2"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.0", "29c31dd4-8ea1-4927-82d9-a0620e04773f"),
 					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+				),
+			},
+			{
+				Config: `
+						resource "scaleway_iam_application" "app03" {
+							name = "third app"
+						}
+						resource "scaleway_iam_application" "app04" {
+							name = "fourth app"
+						}
+						resource "scaleway_iam_group" "main_mix" {
+							name = "iam_group_app"
+							user_ids = [
+								"43b0529c-0b85-45a1-bbf6-5a1336b21787",
+								"0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017",
+								"ce18cffd-e7c8-47f8-8de8-00e97e50a0d3",
+							]
+						}
+					`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIamGroupExists(tt, "scaleway_iam_group.main_mix"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "name", "iam_group_app"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "application_ids.#", "0"),
+					resource.TestCheckNoResourceAttr("scaleway_iam_group.main_mix", "application_ids.0"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.#", "3"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.0", "43b0529c-0b85-45a1-bbf6-5a1336b21787"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.1", "0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"),
+					resource.TestCheckResourceAttr("scaleway_iam_group.main_mix", "user_ids.2", "ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"),
 				),
 			},
 			{

--- a/scaleway/resource_iam_group_test.go
+++ b/scaleway/resource_iam_group_test.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -21,7 +22,11 @@ func testSweepIamGroup(_ string) error {
 	return sweep(func(scwClient *scw.Client) error {
 		api := iam.NewAPI(scwClient)
 
-		listApps, err := api.ListGroups(&iam.ListGroupsRequest{})
+		// Requiring organization_id in list request is temporary
+		organizationID := os.Getenv("DEFAULT_ORGANIZATION_ID")
+		listApps, err := api.ListGroups(&iam.ListGroupsRequest{
+			OrganizationID: &organizationID,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to list groups: %w", err)
 		}

--- a/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:40 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 879f6950-8644-4089-919a-c14703b56a48
+      - f11674a6-48e9-49a9-a7f0-2e09d638fc0f
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:40 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb72eb8d-277d-499e-a3ec-3c8c10941cb9
+      - 1451488d-61bd-4c22-b495-54dd974b337c
     status: 200 OK
     code: 200
     duration: ""
@@ -76,19 +76,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:40 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af49937c-3bea-4a31-b0cb-ebd552020efd
+      - 1b3d1adf-89fb-4003-858c-facff42d77d4
     status: 200 OK
     code: 200
     duration: ""
@@ -109,19 +109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "293"
+      - "301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:40 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba12f70-cd6e-48bd-a130-bd286769c00e
+      - d6ab6910-9142-42ce-9945-3431418b1814
     status: 200 OK
     code: 200
     duration: ""
@@ -142,19 +142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:40 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40a390ac-175e-4b7a-9b38-423eb06a67f2
+      - 5c496f23-8586-4267-ab0a-8ec52c59c524
     status: 200 OK
     code: 200
     duration: ""
@@ -175,19 +175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7775b51f-1374-46ac-bdbc-86b53f273d5f
+      - 2f07489b-1f81-49fd-8142-bf58324783c5
     status: 200 OK
     code: 200
     duration: ""
@@ -208,19 +208,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0da0d72e-0b54-4e74-bc43-51dbf19cb236
+      - 0836dcdc-0231-4a7e-ada6-e31cdc117357
     status: 200 OK
     code: 200
     duration: ""
@@ -241,19 +241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "293"
+      - "301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 038d5a30-7974-4d61-a1e7-1ba46bcf6790
+      - 7157ca77-0240-4ade-baae-104ad057268e
     status: 200 OK
     code: 200
     duration: ""
@@ -274,19 +274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -296,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81377693-af48-47f1-94b3-2081fd35b866
+      - 64de4210-07a1-4b6d-90b1-8a449d8d75e3
     status: 200 OK
     code: 200
     duration: ""
@@ -307,19 +307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,7 +329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bbbd276-a92f-412b-a46b-c2dc1f8d8615
+      - b0fbc70d-71f0-44de-8e00-d822eb190b21
     status: 200 OK
     code: 200
     duration: ""
@@ -340,19 +340,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "264"
+      - "301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7594c878-ec95-460e-ab84-b4cb1736159a
+      - c0b4b69a-55d2-4dd5-80b9-d4eb02d99936
     status: 200 OK
     code: 200
     duration: ""
@@ -373,19 +373,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "293"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -395,7 +395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d81500c-2dd0-4582-99f6-cb067f48062a
+      - 704ecb83-c419-431e-9b0e-cb2668733b4c
     status: 200 OK
     code: 200
     duration: ""
@@ -406,31 +406,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: ""
     headers:
-      Content-Length:
-      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
       - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9a482f2-50f3-4ca0-a4be-789d33bf86bc
-    status: 200 OK
-    code: 200
+      - 9b7919af-7a2a-44bf-9737-9e0a3e4be04f
+    status: 429 Too Many Requests
+    code: 429
     duration: ""
 - request:
     body: ""
@@ -439,19 +437,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -461,7 +459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 586144c0-14d6-4aa9-8091-54d8708ee940
+      - 7b45ed68-8e19-41fd-bc6a-3041266aef0d
     status: 200 OK
     code: 200
     duration: ""
@@ -472,19 +470,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "293"
+      - "272"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -494,7 +492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c760927d-3126-4967-b359-62b4060e802b
+      - 646e3d97-1983-415d-a0d1-3826b4c7e272
     status: 200 OK
     code: 200
     duration: ""
@@ -505,19 +503,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "264"
+      - "301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -527,7 +525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9fdeada-39c7-4fea-808c-d710b470b584
+      - 27a49c36-a00b-4009-b2ed-cb6bc2a8edf2
     status: 200 OK
     code: 200
     duration: ""
@@ -538,7 +536,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    method: GET
+  response:
+    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "272"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8256603-5307-4cc1-b08d-f253f23af4bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: DELETE
   response:
     body: ""
@@ -548,7 +579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -558,7 +589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b22ef0bf-ed4c-43dd-8b36-6c132b2d7dac
+      - 70f1a8b4-d75a-411c-a6d5-22187c37901b
     status: 204 No Content
     code: 204
     duration: ""
@@ -569,10 +600,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -581,7 +612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -591,7 +622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce4b193a-abab-441d-8d56-9a4f7168995e
+      - f2a54390-064d-4c1b-bc74-d46b330121e3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -602,10 +633,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -614,7 +645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -624,7 +655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b38a687-7df5-4264-8312-10b8921d5fef
+      - cecf7707-8533-42ae-b466-e709210612b3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -635,10 +666,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -647,7 +678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 09:14:41 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -657,7 +688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe7b213f-4fd4-4b37-8ff5-f791f93910fd
+      - 12de8da0-5ca1-4533-a799-efe0a89c68b7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f11674a6-48e9-49a9-a7f0-2e09d638fc0f
+      - 58d4f3ee-c950-4a32-994e-cb9b00c2d175
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1451488d-61bd-4c22-b495-54dd974b337c
+      - 262c6abe-1542-49cc-aea5-ba112e6811dd
     status: 200 OK
     code: 200
     duration: ""
@@ -76,10 +76,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b3d1adf-89fb-4003-858c-facff42d77d4
+      - f3b85ddd-1c9e-4d2c-8570-9f57bc96f8f8
     status: 200 OK
     code: 200
     duration: ""
@@ -112,7 +112,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
       - "301"
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6ab6910-9142-42ce-9945-3431418b1814
+      - f951f805-0391-4463-9ad0-10fc4cd31542
     status: 200 OK
     code: 200
     duration: ""
@@ -142,10 +142,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -154,7 +154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c496f23-8586-4267-ab0a-8ec52c59c524
+      - b8b161e3-295f-4acf-8b93-24ec609ce365
     status: 200 OK
     code: 200
     duration: ""
@@ -175,10 +175,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -187,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f07489b-1f81-49fd-8142-bf58324783c5
+      - 9a91f2e1-c5ed-49e6-a844-ed9032343dad
     status: 200 OK
     code: 200
     duration: ""
@@ -208,10 +208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -220,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0836dcdc-0231-4a7e-ada6-e31cdc117357
+      - 5a7cc2af-2bb6-443a-875f-30633d5b4604
     status: 200 OK
     code: 200
     duration: ""
@@ -244,7 +244,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
       - "301"
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7157ca77-0240-4ade-baae-104ad057268e
+      - 53ce3ca1-7d5e-4386-bf9d-6f0ae1bb3a99
     status: 200 OK
     code: 200
     duration: ""
@@ -274,10 +274,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -286,7 +286,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -296,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64de4210-07a1-4b6d-90b1-8a449d8d75e3
+      - e9d6da89-ba14-4ad3-ad0e-ac2250ad0715
     status: 200 OK
     code: 200
     duration: ""
@@ -307,10 +307,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -319,7 +319,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -329,7 +329,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fbc70d-71f0-44de-8e00-d822eb190b21
+      - eea048ca-e852-4fdb-81fb-d24c8fa68237
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
+    method: GET
+  response:
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "272"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:32:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4a0708d-76b0-44d6-bc86-8a6f021c54e6
     status: 200 OK
     code: 200
     duration: ""
@@ -343,7 +376,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
       - "301"
@@ -352,7 +385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -362,7 +395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0b4b69a-55d2-4dd5-80b9-d4eb02d99936
+      - bf7ca561-efdd-48ff-a550-9041a4ab6678
     status: 200 OK
     code: 200
     duration: ""
@@ -373,40 +406,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
-    method: GET
-  response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "272"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 704ecb83-c419-431e-9b0e-cb2668733b4c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
     body: ""
@@ -414,7 +414,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -426,7 +426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b7919af-7a2a-44bf-9737-9e0a3e4be04f
+      - 6ad36745-1a50-4d7e-9484-c26fb3ea66b8
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -437,10 +437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -449,7 +449,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:52 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -459,7 +459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b45ed68-8e19-41fd-bc6a-3041266aef0d
+      - 909f2854-fb17-437e-b72a-c0aa3f167ee0
     status: 200 OK
     code: 200
     duration: ""
@@ -470,10 +470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -482,7 +482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -492,7 +492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 646e3d97-1983-415d-a0d1-3826b4c7e272
+      - 3724d807-29e3-4f27-b340-beb044cc4fe4
     status: 200 OK
     code: 200
     duration: ""
@@ -506,7 +506,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_basic&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    body: '{"groups":[{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
       - "301"
@@ -515,7 +515,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -525,7 +525,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27a49c36-a00b-4009-b2ed-cb6bc2a8edf2
+      - fc6212e1-c3bc-4b29-a04b-a2a912154c8b
     status: 200 OK
     code: 200
     duration: ""
@@ -536,10 +536,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"id":"f3899798-2836-422a-b066-324831e03035","created_at":"2022-06-28T12:20:50.282506Z","updated_at":"2022-06-28T12:20:50.282506Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","created_at":"2022-06-29T13:32:58.049732Z","updated_at":"2022-06-29T13:32:58.049732Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_basic","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "272"
@@ -548,7 +548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -558,7 +558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8256603-5307-4cc1-b08d-f253f23af4bf
+      - 25aa00ed-665e-4b32-8773-f978fdf01852
     status: 200 OK
     code: 200
     duration: ""
@@ -569,7 +569,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: DELETE
   response:
     body: ""
@@ -579,7 +579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -589,7 +589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70f1a8b4-d75a-411c-a6d5-22187c37901b
+      - bf294aa4-21bb-473c-b94c-fbc4e37ee409
     status: 204 No Content
     code: 204
     duration: ""
@@ -600,10 +600,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -612,7 +612,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -622,7 +622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2a54390-064d-4c1b-bc74-d46b330121e3
+      - 1ee679f3-378d-4d88-8645-cdc0e08bb7dc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -633,10 +633,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -645,7 +645,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -655,7 +655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cecf7707-8533-42ae-b466-e709210612b3
+      - f77f8280-da79-45bd-bcbe-05c50f807bbb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -666,10 +666,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/f3899798-2836-422a-b066-324831e03035
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8a2de1c4-dd67-4790-ba6c-62e5535cfeec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"f3899798-2836-422a-b066-324831e03035","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8a2de1c4-dd67-4790-ba6c-62e5535cfeec","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -678,7 +678,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -688,7 +688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12de8da0-5ca1-4533-a799-efe0a89c68b7
+      - 1077251b-f4aa-4cea-a004-5bb8db8d296d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,10 +13,10 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebf42980-94fe-4bd9-842b-6790fa762ee9
+      - 49477192-ed33-4dea-8cff-bea9274da329
     status: 200 OK
     code: 200
     duration: ""
@@ -43,46 +43,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 24 Jun 2022 19:06:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1211d4c6-09f7-4507-a1a1-4761047c47d4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
-    method: GET
-  response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "276"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -98,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84bc5018-e23c-4169-87d5-4b34818991db
+      - 775a296e-1b5e-4474-a161-fe0d48017119
     status: 200 OK
     code: 200
     duration: ""
@@ -109,13 +76,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -131,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c761a4-7c76-45b2-923e-a3ef9e2823d0
+      - 870f43af-4d3b-4e66-a77c-f47c6936bea6
     status: 200 OK
     code: 200
     duration: ""
@@ -142,13 +109,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -164,27 +131,57 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60357a03-93f1-49c7-b375-85baed8213e0
+      - dff28836-a798-4103-9df7-87383048917c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"iam_group_basic","description":"basic description"}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
-    method: PATCH
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 19:06:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 72bc181d-8c80-4987-83c1-e80d661c52b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    method: GET
+  response:
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -200,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff08a5ee-3872-451e-8a45-5c2276d7ae39
+      - a244fa20-be99-4ed9-b8bb-bd25a9774396
     status: 200 OK
     code: 200
     duration: ""
@@ -211,14 +208,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -234,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b33dd37-4dd3-4527-a6c7-1d8847d8babb
+      - 84d4a914-2492-4231-bc54-279c4035e068
     status: 200 OK
     code: 200
     duration: ""
@@ -245,14 +241,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -268,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7b5c33e-9f07-480c-a855-549cc128d809
+      - 4e6867c9-dc7b-48f3-8807-53853ff4a551
     status: 200 OK
     code: 200
     duration: ""
@@ -279,14 +274,47 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 19:06:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f12b201b-f7b3-4f73-8700-a235db6738ed
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"details":[{"argument_name":"organization_id","help_message":"","reason":"required"}],"message":"invalid
+      argument(s)","type":"invalid_arguments"}'
+    headers:
+      Content-Length:
+      - "146"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -302,9 +330,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a00b8ee4-9f1a-4790-bc5f-bbe1a674d141
-    status: 200 OK
-    code: 200
+      - 14c9ebcc-c2d8-45b7-b28a-7a4d54b8cef6
+    status: 400 Bad Request
+    code: 400
     duration: ""
 - request:
     body: ""
@@ -313,7 +341,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: DELETE
   response:
     body: ""
@@ -333,7 +361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 140f8f82-63a1-45c2-be0c-e7a595cf6365
+      - 5472c090-faf3-4e74-919e-be951f6478f6
     status: 204 No Content
     code: 204
     duration: ""
@@ -344,10 +372,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -366,7 +394,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4c6a5c8-cf99-4b4c-9aae-44ab73c6a516
+      - 4bdb61cb-4bbc-4ddc-9571-bec3993fc44a
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 19:06:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0422dd2-752f-49fa-99a4-83e78bb401f5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-basic.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:45 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49477192-ed33-4dea-8cff-bea9274da329
+      - 879f6950-8644-4089-919a-c14703b56a48
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775a296e-1b5e-4474-a161-fe0d48017119
+      - cb72eb8d-277d-499e-a3ec-3c8c10941cb9
     status: 200 OK
     code: 200
     duration: ""
@@ -76,10 +76,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 870f43af-4d3b-4e66-a77c-f47c6936bea6
+      - af49937c-3bea-4a31-b0cb-ebd552020efd
     status: 200 OK
     code: 200
     duration: ""
@@ -109,19 +109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "264"
+      - "293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dff28836-a798-4103-9df7-87383048917c
+      - 2ba12f70-cd6e-48bd-a130-bd286769c00e
     status: 200 OK
     code: 200
     duration: ""
@@ -142,10 +142,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -154,7 +154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72bc181d-8c80-4987-83c1-e80d661c52b4
+      - 40a390ac-175e-4b7a-9b38-423eb06a67f2
     status: 200 OK
     code: 200
     duration: ""
@@ -175,10 +175,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -187,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a244fa20-be99-4ed9-b8bb-bd25a9774396
+      - 7775b51f-1374-46ac-bdbc-86b53f273d5f
     status: 200 OK
     code: 200
     duration: ""
@@ -208,10 +208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -220,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84d4a914-2492-4231-bc54-279c4035e068
+      - 0da0d72e-0b54-4e74-bc43-51dbf19cb236
     status: 200 OK
     code: 200
     duration: ""
@@ -241,19 +241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
     headers:
       Content-Length:
-      - "264"
+      - "293"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e6867c9-dc7b-48f3-8807-53853ff4a551
+      - 038d5a30-7974-4d61-a1e7-1ba46bcf6790
     status: 200 OK
     code: 200
     duration: ""
@@ -274,10 +274,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","created_at":"2022-06-24T19:06:45.683233Z","updated_at":"2022-06-24T19:06:45.683233Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -286,7 +286,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -296,7 +296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f12b201b-f7b3-4f73-8700-a235db6738ed
+      - 81377693-af48-47f1-94b3-2081fd35b866
     status: 200 OK
     code: 200
     duration: ""
@@ -307,20 +307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"details":[{"argument_name":"organization_id","help_message":"","reason":"required"}],"message":"invalid
-      argument(s)","type":"invalid_arguments"}'
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "146"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -330,9 +329,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14c9ebcc-c2d8-45b7-b28a-7a4d54b8cef6
-    status: 400 Bad Request
-    code: 400
+      - 0bbbd276-a92f-412b-a46b-c2dc1f8d8615
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -341,7 +340,205 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    method: GET
+  response:
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7594c878-ec95-460e-ab84-b4cb1736159a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "293"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d81500c-2dd0-4582-99f6-cb067f48062a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    method: GET
+  response:
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9a482f2-50f3-4ca0-a4be-789d33bf86bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    method: GET
+  response:
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 586144c0-14d6-4aa9-8091-54d8708ee940
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "293"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c760927d-3126-4967-b359-62b4060e802b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    method: GET
+  response:
+    body: '{"id":"903c51a5-24cd-4080-83dd-ca79869df6c1","created_at":"2022-06-27T09:14:40.757880Z","updated_at":"2022-06-27T09:14:40.757880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d9fdeada-39c7-4fea-808c-d710b470b584
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: DELETE
   response:
     body: ""
@@ -351,7 +548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -361,7 +558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5472c090-faf3-4e74-919e-be951f6478f6
+      - b22ef0bf-ed4c-43dd-8b36-6c132b2d7dac
     status: 204 No Content
     code: 204
     duration: ""
@@ -372,10 +569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -384,7 +581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -394,7 +591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bdb61cb-4bbc-4ddc-9571-bec3993fc44a
+      - ce4b193a-abab-441d-8d56-9a4f7168995e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -405,10 +602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/15e897bd-dd3a-4df2-a9bc-325255be8e68
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"15e897bd-dd3a-4df2-a9bc-325255be8e68","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -417,7 +614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -427,7 +624,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0422dd2-752f-49fa-99a4-83e78bb401f5
+      - 8b38a687-7df5-4264-8312-10b8921d5fef
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/903c51a5-24cd-4080-83dd-ca79869df6c1
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"903c51a5-24cd-4080-83dd-ca79869df6c1","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 09:14:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe7b213f-4fd4-4b37-8ff5-f791f93910fd
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
@@ -1,0 +1,830 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"first app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications
+    method: POST
+  response:
+    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1870cb3f-8e08-4593-a50b-38d939d338e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    method: GET
+  response:
+    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9092ab0-c7ab-447c-b8bc-e32c725b76e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups
+    method: POST
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a643761-d9f0-494e-9629-1662ef4f40c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87/principals
+    method: PUT
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - afa43ae6-4c5b-4bcc-a723-3c8ce0e41bd8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce3f6718-d9cd-4d00-a725-25e412e5560b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 081430a2-9398-471e-a6d0-39fe8d3afe44
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08fc5f81-5fab-4068-9e35-b7d1bdf556ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b32b3b6-54b1-4020-8281-158d0fa5ab14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a7ab896-e183-4b8f-8495-8abf51fff142
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d928193-c72d-4924-952d-4645d1822e1e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a48549a7-d991-46d1-a38e-fefcb30eb0e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83f3b889-c41a-4c9b-8c4d-774ed6cb62c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    method: GET
+  response:
+    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 595f4c3b-d148-42a8-9a53-3a1bf0ed6828
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 88fee4df-3362-4051-b44e-176f73786e95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8988630a-9708-427f-8115-07dbbd34d47c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b98e058-a7c7-49b5-ae1c-14762e1cc81c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5bb0fa7-3219-4b41-bf5a-a1fc17efc0df
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40bcd7f2-ebb9-464c-8e72-c3b5c98973a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    method: GET
+  response:
+    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "408"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a6df7750-bdb3-4b0c-b917-d1fd5dd02a61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8eb20f28-8d3b-4e8e-989a-371fd499e5a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ba778b83-b9ca-4131-b5e2-c96805406a40
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 453d278b-7013-4c49-be1d-934b87d0cfbd
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce9841ea-4d50-4282-b137-b7548e7ce791
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f50adddb-89f0-499d-a824-ce88e1870a73
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:38:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a7b66ee9-1dbc-43ac-a3bf-bfb308ba3460
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"980358c1-6645-4e99-901f-5443965d0f95","name":"app","description":"","created_at":"2022-06-29T13:32:58.054546Z","updated_at":"2022-06-29T13:32:58.054546Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "250"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad30ab6e-a6d7-4c67-9471-6ed8b43acc9c
+      - 549f3c29-2b87-4d36-a45a-2edcf2d6350e
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/980358c1-6645-4e99-901f-5443965d0f95
     method: GET
   response:
-    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"980358c1-6645-4e99-901f-5443965d0f95","name":"app","description":"","created_at":"2022-06-29T13:32:58.054546Z","updated_at":"2022-06-29T13:32:58.054546Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "250"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0150477a-3fa4-4ddb-a021-3b1dab9f7c3f
+      - 72ea7fc9-e314-4273-b9dd-77a356ba35a0
     status: 200 OK
     code: 200
     duration: ""
@@ -81,7 +81,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "270"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a29efeb-ae08-40a8-bc90-b117acd6a5ad
+      - 36804e69-3d20-4943-94d9-0c1a94cdee8f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401/members
     method: PUT
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf12fa34-7a86-4bc6-8663-5cbb66f5d9f6
+      - 7efb1e14-1e37-4b82-a19e-7087dc6eee02
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95c8d60e-4172-4f05-9620-a1535952bef7
+      - cd4c8b5a-36f6-4c7f-bac0-7de89a067400
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
+    method: GET
+  response:
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
+    headers:
+      Content-Length:
+      - "385"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:32:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1694c43a-1fd6-4a97-b4b7-4e86bf43141e
     status: 200 OK
     code: 200
     duration: ""
@@ -182,7 +215,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
+    body: '{"groups":[{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}],"total_count":1}'
     headers:
       Content-Length:
       - "414"
@@ -191,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 611fd13d-de63-4ef6-ba7b-8d072c123282
+      - 0b48a802-612c-4e15-baa7-73a522479c31
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -224,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00e27cbb-6dac-48e7-a40d-41978db2319f
+      - 2c7c3780-7670-48c1-bfd5-e4c9ad773f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +278,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -257,7 +290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4fd4ad6-b62b-402a-9757-d077d1ca3691
+      - ac4a1fe5-8d80-4493-a998-80daa3a9c56f
     status: 200 OK
     code: 200
     duration: ""
@@ -278,10 +311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -290,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,40 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac20f8ae-f828-4c7f-ad87-16cf93735ad0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
-    method: GET
-  response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
-    headers:
-      Content-Length:
-      - "385"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b280eeb-2fd9-4424-ad42-ce04df5d1f70
+      - 47699fe3-0ec0-4403-b747-ebe1bb02b0a4
     status: 200 OK
     code: 200
     duration: ""
@@ -347,7 +347,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
+    body: '{"groups":[{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}],"total_count":1}'
     headers:
       Content-Length:
       - "414"
@@ -356,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61ecb142-1659-431b-a2ef-a3b3000ec5c7
+      - 18cf588b-c030-4f71-a8de-5c752d9cedce
     status: 200 OK
     code: 200
     duration: ""
@@ -377,10 +377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e5d6520-3d77-4b6b-8954-a494aeb37b97
+      - a90664d9-23dc-4fce-910c-f3d7b04366f1
     status: 200 OK
     code: 200
     duration: ""
@@ -410,7 +410,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/980358c1-6645-4e99-901f-5443965d0f95
     method: GET
   response:
     body: ""
@@ -418,7 +418,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -430,7 +430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cb46eec-942a-4152-b054-bcf3dfdcb47e
+      - cfa9796c-d8d7-49df-998f-1041e83b8f02
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -441,10 +441,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/980358c1-6645-4e99-901f-5443965d0f95
     method: GET
   response:
-    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"980358c1-6645-4e99-901f-5443965d0f95","name":"app","description":"","created_at":"2022-06-29T13:32:58.054546Z","updated_at":"2022-06-29T13:32:58.054546Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "250"
@@ -453,7 +453,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1b675bf-4a96-445c-acd5-a97d5c9cab07
+      - 4d398db2-436c-48e2-8a37-7f6971a7c5e2
     status: 200 OK
     code: 200
     duration: ""
@@ -474,10 +474,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -486,7 +486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 517adcb4-7f8f-4cfb-9496-6372da0acf36
+      - 6970a61e-213b-4869-a1b4-13b8a7cbf5d9
     status: 200 OK
     code: 200
     duration: ""
@@ -510,7 +510,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
+    body: '{"groups":[{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}],"total_count":1}'
     headers:
       Content-Length:
       - "414"
@@ -519,7 +519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b1c3fb9-74c2-4b36-8419-be9761d82aa2
+      - d10fd3c3-f0b9-44dd-b7ed-f9444ad666bb
     status: 200 OK
     code: 200
     duration: ""
@@ -540,10 +540,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -552,7 +552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -562,7 +562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72c291b1-4669-488e-9ef0-ba78f12a46c3
+      - 14527ce0-96bb-413e-9d32-7c8ec774534c
     status: 200 OK
     code: 200
     duration: ""
@@ -573,10 +573,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -585,7 +585,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -595,7 +595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71291a9d-85f1-4c94-bcc0-ddd74fb58360
+      - fb77c603-ccc4-49ce-bd4d-215a7f296ea1
     status: 200 OK
     code: 200
     duration: ""
@@ -606,10 +606,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -618,7 +618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -628,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e8252b9-6f92-4f49-8fa0-4b4d2de420a0
+      - 87fb4bff-90e1-42b3-8c41-f56a5b2826e3
     status: 200 OK
     code: 200
     duration: ""
@@ -642,7 +642,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
+    body: '{"groups":[{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}],"total_count":1}'
     headers:
       Content-Length:
       - "414"
@@ -651,7 +651,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -661,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62591bcd-bded-42be-bb31-98a5ed355804
+      - 97a27a23-f19b-4994-8944-87db02c917d5
     status: 200 OK
     code: 200
     duration: ""
@@ -672,10 +672,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    body: '{"id":"8303f586-86f0-4661-a787-f0d431132401","created_at":"2022-06-29T13:32:58.185622Z","updated_at":"2022-06-29T13:32:58.185622Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["980358c1-6645-4e99-901f-5443965d0f95"]}'
     headers:
       Content-Length:
       - "385"
@@ -684,7 +684,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -694,7 +694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bed352ab-5e5a-49ad-84b0-7ed2c8c1cb79
+      - f300400f-95b7-49c1-b9f8-a523795cd95c
     status: 200 OK
     code: 200
     duration: ""
@@ -705,7 +705,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: DELETE
   response:
     body: ""
@@ -715,7 +715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -725,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7af59534-caff-41d7-ada3-efa33867cbf7
+      - a3780949-16a2-44b2-8e96-fa1359bc5832
     status: 204 No Content
     code: 204
     duration: ""
@@ -736,7 +736,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/980358c1-6645-4e99-901f-5443965d0f95
     method: DELETE
   response:
     body: ""
@@ -746,7 +746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -756,7 +756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dd832da-f549-47d1-981e-d780c06b0fc5
+      - 9fc954c0-3bf5-49e5-9fbd-572e96da1d71
     status: 204 No Content
     code: 204
     duration: ""
@@ -767,10 +767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8303f586-86f0-4661-a787-f0d431132401","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -779,7 +779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -789,7 +789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 122bc053-e93b-4912-b8f5-e857bd42a893
+      - 60165bec-4198-492d-ad67-a7779a11cef0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -800,7 +800,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8303f586-86f0-4661-a787-f0d431132401","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a3ee22aa-206f-49af-b577-88cdb979aecb
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
     body: ""
@@ -808,7 +841,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -820,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6353306-8ab2-445d-9c61-65df21d0d79d
+      - 23c00bbd-597f-4186-ad94-c09a9a119c68
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -831,10 +864,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8303f586-86f0-4661-a787-f0d431132401
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8303f586-86f0-4661-a787-f0d431132401","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -843,7 +876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -853,40 +886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d12831-ed36-4086-acf6-a3c0682a9edf
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "126"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c890960f-15be-487b-b72b-fe06e0c9e6fe
+      - 5a3ec5b5-c806-4290-8912-31195b0563da
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/data-source-iam-group-users-and-applications.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"first app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    body: '{"name":"app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "256"
+      - "250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:22 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1870cb3f-8e08-4593-a50b-38d939d338e8
+      - ad30ab6e-a6d7-4c67-9471-6ed8b43acc9c
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
     method: GET
   response:
-    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "256"
+      - "250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:22 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,12 +65,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9092ab0-c7ab-447c-b8bc-e32c725b76e7
+      - 0150477a-3fa4-4ddb-a021-3b1dab9f7c3f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -81,16 +81,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "264"
+      - "270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:22 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a643761-d9f0-494e-9629-1662ef4f40c6
+      - 1a29efeb-ae08-40a8-bc90-b117acd6a5ad
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,19 +113,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60/principals
     method: PUT
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:22 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afa43ae6-4c5b-4bcc-a723-3c8ce0e41bd8
+      - bf12fa34-7a86-4bc6-8663-5cbb66f5d9f6
     status: 200 OK
     code: 200
     duration: ""
@@ -146,19 +146,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:22 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce3f6718-d9cd-4d00-a725-25e412e5560b
+      - 95c8d60e-4172-4f05-9620-a1535952bef7
     status: 200 OK
     code: 200
     duration: ""
@@ -179,19 +179,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
     headers:
       Content-Length:
-      - "379"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 081430a2-9398-471e-a6d0-39fe8d3afe44
+      - 611fd13d-de63-4ef6-ba7b-8d072c123282
     status: 200 OK
     code: 200
     duration: ""
@@ -212,19 +212,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "408"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08fc5f81-5fab-4068-9e35-b7d1bdf556ac
+      - 00e27cbb-6dac-48e7-a40d-41978db2319f
     status: 200 OK
     code: 200
     duration: ""
@@ -245,19 +245,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b32b3b6-54b1-4020-8281-158d0fa5ab14
+      - f4fd4ad6-b62b-402a-9757-d077d1ca3691
     status: 200 OK
     code: 200
     duration: ""
@@ -278,19 +278,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a7ab896-e183-4b8f-8495-8abf51fff142
+      - ac20f8ae-f828-4c7f-ad87-16cf93735ad0
     status: 200 OK
     code: 200
     duration: ""
@@ -311,19 +311,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "408"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d928193-c72d-4924-952d-4645d1822e1e
+      - 2b280eeb-2fd9-4424-ad42-ce04df5d1f70
     status: 200 OK
     code: 200
     duration: ""
@@ -344,19 +344,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
     headers:
       Content-Length:
-      - "379"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a48549a7-d991-46d1-a38e-fefcb30eb0e7
+      - 61ecb142-1659-431b-a2ef-a3b3000ec5c7
     status: 200 OK
     code: 200
     duration: ""
@@ -377,19 +377,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83f3b889-c41a-4c9b-8c4d-774ed6cb62c5
+      - 9e5d6520-3d77-4b6b-8954-a494aeb37b97
     status: 200 OK
     code: 200
     duration: ""
@@ -410,31 +410,29 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
     method: GET
   response:
-    body: '{"id":"9ec74a1a-89ea-4e9c-9dc0-a910518551ef","name":"first app","description":"","created_at":"2022-06-28T11:38:22.638286Z","updated_at":"2022-06-28T11:38:22.638286Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: ""
     headers:
-      Content-Length:
-      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
       - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 595f4c3b-d148-42a8-9a53-3a1bf0ed6828
-    status: 200 OK
-    code: 200
+      - 0cb46eec-942a-4152-b054-bcf3dfdcb47e
+    status: 429 Too Many Requests
+    code: 429
     duration: ""
 - request:
     body: ""
@@ -443,19 +441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"9f2c0722-c883-4fef-8d67-dc6c8ea58c0b","name":"app","description":"","created_at":"2022-06-28T12:20:50.276251Z","updated_at":"2022-06-28T12:20:50.276251Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "379"
+      - "250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88fee4df-3362-4051-b44e-176f73786e95
+      - c1b675bf-4a96-445c-acd5-a97d5c9cab07
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "408"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8988630a-9708-427f-8115-07dbbd34d47c
+      - 517adcb4-7f8f-4cfb-9496-6372da0acf36
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
     headers:
       Content-Length:
-      - "379"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b98e058-a7c7-49b5-ae1c-14762e1cc81c
+      - 2b1c3fb9-74c2-4b36-8419-be9761d82aa2
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +540,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5bb0fa7-3219-4b41-bf5a-a1fc17efc0df
+      - 72c291b1-4669-488e-9ef0-ba78f12a46c3
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +573,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "379"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40bcd7f2-ebb9-464c-8e72-c3b5c98973a4
+      - 71291a9d-85f1-4c94-bcc0-ddd74fb58360
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +606,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test-terraform&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"groups":[{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}],"total_count":1}'
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
     headers:
       Content-Length:
-      - "408"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6df7750-bdb3-4b0c-b917-d1fd5dd02a61
+      - 8e8252b9-6f92-4f49-8fa0-4b4d2de420a0
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +639,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups?name=test_data_source_mix&order_by=created_at_asc&organization_id=08555df8-bb26-43bc-b749-1b98c5d02343
     method: GET
   response:
-    body: '{"id":"5122ea8d-e702-4e58-b57a-70a308719c87","created_at":"2022-06-28T11:38:22.781207Z","updated_at":"2022-06-28T11:38:22.781207Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test-terraform","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9ec74a1a-89ea-4e9c-9dc0-a910518551ef"]}'
+    body: '{"groups":[{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}],"total_count":1}'
     headers:
       Content-Length:
-      - "379"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8eb20f28-8d3b-4e8e-989a-371fd499e5a0
+      - 62591bcd-bded-42be-bb31-98a5ed355804
     status: 200 OK
     code: 200
     duration: ""
@@ -674,7 +672,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    method: GET
+  response:
+    body: '{"id":"76b92d41-9930-4272-b3f6-14057aedcf60","created_at":"2022-06-28T12:20:50.434430Z","updated_at":"2022-06-28T12:20:50.434430Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"test_data_source_mix","description":"","user_ids":["ce18cffd-e7c8-47f8-8de8-00e97e50a0d3","255b63c2-b4de-4af6-9ed4-967f69d9dd85"],"application_ids":["9f2c0722-c883-4fef-8d67-dc6c8ea58c0b"]}'
+    headers:
+      Content-Length:
+      - "385"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bed352ab-5e5a-49ad-84b0-7ed2c8c1cb79
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: DELETE
   response:
     body: ""
@@ -684,7 +715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:23 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -694,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba778b83-b9ca-4131-b5e2-c96805406a40
+      - 7af59534-caff-41d7-ada3-efa33867cbf7
     status: 204 No Content
     code: 204
     duration: ""
@@ -705,7 +736,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/9ec74a1a-89ea-4e9c-9dc0-a910518551ef
+    url: https://api.scaleway.com/iam/v1alpha1/applications/9f2c0722-c883-4fef-8d67-dc6c8ea58c0b
     method: DELETE
   response:
     body: ""
@@ -715,7 +746,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:24 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -725,7 +756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 453d278b-7013-4c49-be1d-934b87d0cfbd
+      - 3dd832da-f549-47d1-981e-d780c06b0fc5
     status: 204 No Content
     code: 204
     duration: ""
@@ -736,10 +767,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -748,7 +779,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:24 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -758,7 +789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce9841ea-4d50-4282-b137-b7548e7ce791
+      - 122bc053-e93b-4912-b8f5-e857bd42a893
     status: 404 Not Found
     code: 404
     duration: ""
@@ -769,10 +800,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a6353306-8ab2-445d-9c61-65df21d0d79d
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -781,7 +843,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:24 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -791,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f50adddb-89f0-499d-a824-ce88e1870a73
+      - d8d12831-ed36-4086-acf6-a3c0682a9edf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -802,10 +864,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/5122ea8d-e702-4e58-b57a-70a308719c87
+    url: https://api.scaleway.com/iam/v1alpha1/groups/76b92d41-9930-4272-b3f6-14057aedcf60
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"5122ea8d-e702-4e58-b57a-70a308719c87","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"76b92d41-9930-4272-b3f6-14057aedcf60","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -814,7 +876,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:38:24 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -824,7 +886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7b66ee9-1dbc-43ac-a3bf-bfb308ba3460
+      - c890960f-15be-487b-b72b-fe06e0c9e6fe
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-applications.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29375cb8-18b8-49e4-8f1a-645430ded8e3
+      - d5f428ab-f474-49bf-9b0a-fca0c4876cbd
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 628d7a22-ddd1-4088-9206-2e6ea09e42aa
+      - 8d3995bf-8e76-4b5c-bba5-3ad3734e2e15
     status: 200 OK
     code: 200
     duration: ""
@@ -81,7 +81,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c92443c-589e-41b8-bb61-f1af0c7e59c5
+      - e89f56ea-bcc5-4465-abf6-aeaabd639650
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"user_ids":null,"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446/members
     method: PUT
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ed0d968-dcb2-4e8a-b8d7-ca089719dae4
+      - e5d58f17-a695-4a3d-a79c-fe2678b92f63
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b8f81cb-09f2-4321-8fd8-370cf3f5e7c2
+      - c3fa9c83-d734-46af-a84e-1edaa269f082
     status: 200 OK
     code: 200
     duration: ""
@@ -179,10 +179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b24e29d-c0ff-4bb7-b9d0-d5406211eb72
+      - b42a9556-8269-41f9-8436-667a9fc8c2a6
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +212,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af9cdffb-997e-4437-88df-4382a0b055a5
+      - 05dbbf10-bbe1-4cce-9277-ec1c26df9c06
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0df7d5de-58b7-460c-99a6-d4ca1e9bd936
+      - 748a19b9-a135-4710-948e-8c37782f235c
     status: 200 OK
     code: 200
     duration: ""
@@ -278,7 +278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
     body: ""
@@ -286,7 +286,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e324ebc-82ea-47b0-a0a1-784755ec61d7
+      - f6d14170-4b15-43a9-908a-66cc29fa6076
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -309,10 +309,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -321,7 +321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5183010e-6766-49e2-b163-5c5582cc747a
+      - f9e9b32b-6934-4eb8-812f-9e334465c400
     status: 200 OK
     code: 200
     duration: ""
@@ -342,10 +342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -354,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 249af2d4-8814-49d2-b015-8353787c42fe
+      - 7a7f5e7d-22e0-4f20-9dfa-51c4154e2951
     status: 200 OK
     code: 200
     duration: ""
@@ -380,7 +380,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ed9ed24-0081-4ab1-ba37-16d70e3ed613
+      - 0666d929-c41d-403d-923c-3962651b5909
     status: 200 OK
     code: 200
     duration: ""
@@ -410,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 367637b6-2872-41fc-9e43-ee88ab159f76
+      - e15f372c-6bbb-44cb-b207-e1f9b120427e
     status: 200 OK
     code: 200
     duration: ""
@@ -443,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8"]}'
     headers:
       Content-Length:
       - "301"
@@ -455,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,12 +465,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 131e5c35-bfb5-4395-8750-eec8fe746f38
+      - 09c34234-ae51-4651-b4cf-19173c4db87d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"user_ids":null,"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     form: {}
     headers:
       Content-Type:
@@ -478,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446/members
     method: PUT
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "340"
@@ -490,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f813527e-4707-47ca-b784-3db41cb5616b
+      - 1bf6f223-52f4-484f-86b6-8f11a31ecc9a
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: PATCH
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "340"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6d8de59-7c14-423e-ae4c-7e0b0b6e94b9
+      - 01e40e19-87d3-45c4-b6a5-f0e4c5997fb2
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "340"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 727ede35-5569-4ab3-bb86-f32105991ed4
+      - 232d1e30-a56b-49fb-ab2f-220f4240aa0c
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 29 Jun 2022 13:33:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a98a7a1-d6d2-4887-94e1-032e651123b3
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
+    method: GET
+  response:
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "340"
@@ -591,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d55af04c-d9e7-4c02-bc20-4ceaef5c0882
+      - d7552af2-8a6b-4e54-aaa9-65626db647ac
     status: 200 OK
     code: 200
     duration: ""
@@ -612,43 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "256"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53026747-8168-4be2-8adf-14c861bf9b44
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
-    method: GET
-  response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -657,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7875b17c-31d4-43b9-ac30-2d002c7b1d05
+      - a7b82c8a-3509-4be7-9a37-4d74bb1a131c
     status: 200 OK
     code: 200
     duration: ""
@@ -678,76 +676,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
-    headers:
-      Content-Length:
-      - "340"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61ee217f-090a-4fc1-b19d-934cd436db56
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
-    method: GET
-  response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "257"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a009fa79-3a89-4557-b066-3bba00f4b1b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
-    method: GET
-  response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -756,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3883c1ab-f894-4327-a129-ae18a2410c9f
+      - 08b67cb1-93a3-42e2-8ea5-e8e6ef327a8d
     status: 200 OK
     code: 200
     duration: ""
@@ -777,10 +709,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "340"
@@ -789,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83ac2931-29bc-4106-9e11-a587f2befa84
+      - 17bdb66f-724d-450f-a268-3ec7a2c9bb61
     status: 200 OK
     code: 200
     duration: ""
@@ -810,19 +742,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "340"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,12 +764,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f01521f1-e2f7-49a6-a26a-62ebe39047ff
+      - c2ac5602-39c5-4575-b305-9010f010ca95
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
+    method: GET
+  response:
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a08e169-e440-474b-8e42-363dee90ffcb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
+    method: GET
+  response:
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7713935d-5f4b-4c25-905b-04dfd6a4d6e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
+    method: GET
+  response:
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["66162e02-dee9-43c6-b79e-081b660f26e8","18100096-ad9a-453f-be1f-5653969d4bd5"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2f06c2c1-2701-47e4-948f-e3a503d7812d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":null,"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     form: {}
     headers:
       Content-Type:
@@ -845,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446/members
     method: PUT
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -857,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fe0f4e5-1a6c-4862-8a4c-49824c859c61
+      - 9f68a8bc-1ec5-43a2-8f47-7b38e3edce0b
     status: 200 OK
     code: 200
     duration: ""
@@ -880,10 +911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: PATCH
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -892,7 +923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9805fbc-be2a-458a-8994-e7f30b88072b
+      - 75bb08f5-3808-498c-9ca7-e0260cd14682
     status: 200 OK
     code: 200
     duration: ""
@@ -913,10 +944,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -925,7 +956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a01c75d-5385-4129-a912-fbcc61b73e8c
+      - e3670188-0091-4e87-8b71-897388faa5b6
     status: 200 OK
     code: 200
     duration: ""
@@ -946,10 +977,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -958,7 +989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daa4880f-9368-4284-a36e-dd4a53158fed
+      - 78291a8a-7a58-4fa1-9d3a-1fe88ba96bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -979,10 +1010,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -991,7 +1022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1001,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4422d4cd-4eb1-4dc9-9c93-33b7ae4ea645
+      - 699c9d8f-ebaf-4ba4-9bcd-551543ceb5e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,10 +1043,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1024,7 +1055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb02af3a-ce91-4a04-afa3-ac91d7243dcb
+      - 07c751a6-67d7-4f3c-865a-6b1036cfafc8
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,10 +1076,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -1057,7 +1088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1067,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 187b1fb9-338a-40cf-a987-775dcf550dd9
+      - b8c4a697-21c3-4c75-a24b-bb01ba0a0b88
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,10 +1109,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1090,7 +1121,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1100,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c632717-2248-4a84-a4a7-04db95d608b0
+      - dc365abf-179a-4f8c-8ab5-d0b869786814
     status: 200 OK
     code: 200
     duration: ""
@@ -1111,10 +1142,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -1123,7 +1154,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1133,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 225945cf-5c00-4613-ae36-fa3e2d54067e
+      - d18eaf12-1ca0-463a-8734-83873e1d48dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,10 +1175,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1156,7 +1187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4c487bc-07c0-413f-854a-b7c61d97bbfc
+      - 678ba43e-43d1-4467-927b-05752701ee07
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,10 +1208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["18100096-ad9a-453f-be1f-5653969d4bd5"]}'
     headers:
       Content-Length:
       - "301"
@@ -1189,7 +1220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,21 +1230,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e5083c9-2957-4869-bf43-78f279e26431
+      - b97a3230-ad76-4fdf-9b62-6f4c90171a80
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"application_id":"18100096-ad9a-453f-be1f-5653969d4bd5"}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals/194d77a7-b295-496f-92b1-4f2fcbe9c84c
-    method: DELETE
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446/remove-member
+    method: POST
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
     headers:
       Content-Length:
       - "301"
@@ -1222,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 858cc57d-e0bf-48b7-9c8b-1d3cbb926b9a
+      - fd449ffb-2ebe-4042-98e2-f6d977095240
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,10 +1278,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: PATCH
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1257,7 +1290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1267,7 +1300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28cd5946-7fcd-48e6-8ad9-6972b1fe9a4d
+      - fb63a368-12c8-442d-b410-38d2c6cf319a
     status: 200 OK
     code: 200
     duration: ""
@@ -1278,10 +1311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1290,7 +1323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1300,7 +1333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14dc2914-50d1-45e5-b40e-d36748013659
+      - 9a94ea93-e536-4660-bc6f-13643074eaff
     status: 200 OK
     code: 200
     duration: ""
@@ -1311,10 +1344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1323,7 +1356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1333,7 +1366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7903d87-f2ad-4a40-9eb5-de17d68e77a3
+      - 9186b044-a5a5-4ffc-89ea-f48e1424f589
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,19 +1377,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","created_at":"2022-06-29T13:32:58.182258Z","updated_at":"2022-06-29T13:32:58.182258Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "256"
+      - "263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1366,7 +1399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3443d953-5f08-475a-a56d-deff54a5bceb
+      - eb3dde6a-435b-4433-8c20-b0b2ed107af4
     status: 200 OK
     code: 200
     duration: ""
@@ -1377,10 +1410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"18100096-ad9a-453f-be1f-5653969d4bd5","name":"second app","description":"","created_at":"2022-06-29T13:33:01.218136Z","updated_at":"2022-06-29T13:33:01.218136Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1389,7 +1422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1399,7 +1432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8819fc3-0f9f-4353-bb89-d87fb9ef4c92
+      - 96a79c78-a130-47ab-9d7a-4d79703220f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1410,19 +1443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"66162e02-dee9-43c6-b79e-081b660f26e8","name":"first app","description":"","created_at":"2022-06-29T13:32:58.051412Z","updated_at":"2022-06-29T13:32:58.051412Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "263"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1432,7 +1465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51b73078-0832-4c57-9a97-466651f21763
+      - a5dfa641-045c-44bd-a034-28501c802893
     status: 200 OK
     code: 200
     duration: ""
@@ -1443,7 +1476,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: DELETE
   response:
     body: ""
@@ -1453,7 +1486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1463,7 +1496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5c042e7-43de-4290-8133-c65b59dd1063
+      - ce860c53-9a12-4746-9912-335e3a239269
     status: 204 No Content
     code: 204
     duration: ""
@@ -1474,7 +1507,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: DELETE
   response:
     body: ""
@@ -1484,7 +1517,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1494,7 +1527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25552ec7-d2af-4c50-afc6-ab8a4b0a48db
+      - 73ca37bb-6262-486f-bffe-46dd4daa8fc5
     status: 204 No Content
     code: 204
     duration: ""
@@ -1505,7 +1538,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: DELETE
   response:
     body: ""
@@ -1515,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1525,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 573e71f5-3182-4e3d-9da6-db5fe0a5e817
+      - b60772de-ccad-45f9-a9bf-0822cf88f547
     status: 204 No Content
     code: 204
     duration: ""
@@ -1536,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c3f6a4ae-d803-44dc-9ee2-b640e1efe446
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"c3f6a4ae-d803-44dc-9ee2-b640e1efe446","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -1548,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1558,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd7cf78-b118-4cf7-9026-eaa68799f90b
+      - c14b3d8b-8f10-4e52-95fe-26989595dbd4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1569,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    url: https://api.scaleway.com/iam/v1alpha1/applications/66162e02-dee9-43c6-b79e-081b660f26e8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"66162e02-dee9-43c6-b79e-081b660f26e8","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1581,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1591,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71e2081f-ff69-4930-ab88-20b292eea607
+      - f9b7b28d-adc8-4702-9259-4e161f69f7ce
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1602,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/18100096-ad9a-453f-be1f-5653969d4bd5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"18100096-ad9a-453f-be1f-5653969d4bd5","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1614,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d42fe43-ff19-48ea-a8b9-221248f7f317
+      - 2b979e9a-8482-4cd3-9b99-2f5020a723e1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-applications.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05a0413-91a0-4762-86d9-5e4923f02388
+      - 29375cb8-18b8-49e4-8f1a-645430ded8e3
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6131cdc8-b6e9-4783-ac03-e4e8012fddbc
+      - 628d7a22-ddd1-4088-9206-2e6ea09e42aa
     status: 200 OK
     code: 200
     duration: ""
@@ -81,7 +81,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe88f1cb-70b4-4d36-839b-38b3aac3220a
+      - 0c92443c-589e-41b8-bb61-f1af0c7e59c5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"user_ids":null,"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
     method: PUT
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40bafe3f-df0b-4e5b-bcbc-10a47d3f7f81
+      - 0ed0d968-dcb2-4e8a-b8d7-ca089719dae4
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6476d897-ac40-40fe-bb32-eeedd420c1e3
+      - 1b8f81cb-09f2-4321-8fd8-370cf3f5e7c2
     status: 200 OK
     code: 200
     duration: ""
@@ -179,10 +179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8e3d3d7-cccf-4ddd-9b90-7423e42b0ea1
+      - 1b24e29d-c0ff-4bb7-b9d0-d5406211eb72
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +212,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2fb5c91-69c3-4ebd-adb7-9517a21020e5
+      - af9cdffb-997e-4437-88df-4382a0b055a5
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45f23182-647a-4fd6-b0e1-750b777955a0
+      - 0df7d5de-58b7-460c-99a6-d4ca1e9bd936
     status: 200 OK
     code: 200
     duration: ""
@@ -278,10 +278,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e324ebc-82ea-47b0-a0a1-784755ec61d7
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    method: GET
+  response:
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -290,7 +321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9e95966-4865-4f47-a7c3-6e313982f003
+      - 5183010e-6766-49e2-b163-5c5582cc747a
     status: 200 OK
     code: 200
     duration: ""
@@ -311,10 +342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -323,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6e70289-d9d8-47ee-804c-8e3cf417215d
+      - 249af2d4-8814-49d2-b015-8353787c42fe
     status: 200 OK
     code: 200
     duration: ""
@@ -349,7 +380,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -358,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a3d6fa9-61a3-42f2-9c9f-74261ce5f5ca
+      - 8ed9ed24-0081-4ab1-ba37-16d70e3ed613
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -391,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcde0de0-eee1-4c87-b884-7b2671707aa8
+      - 367637b6-2872-41fc-9e43-ee88ab159f76
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5"]}'
     headers:
       Content-Length:
       - "301"
@@ -424,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,12 +465,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9562cc09-5d8c-4f35-82fd-0c3d8dddfdd0
+      - 131e5c35-bfb5-4395-8750-eec8fe746f38
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"user_ids":null,"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     form: {}
     headers:
       Content-Type:
@@ -447,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
     method: PUT
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -459,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45f388c2-777e-4d89-90ed-2b5b5deb3688
+      - f813527e-4707-47ca-b784-3db41cb5616b
     status: 200 OK
     code: 200
     duration: ""
@@ -482,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: PATCH
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -494,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f11b242-d5ee-412b-a142-a8b28430f10a
+      - e6d8de59-7c14-423e-ae4c-7e0b0b6e94b9
     status: 200 OK
     code: 200
     duration: ""
@@ -515,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -527,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbc44c46-c634-4d2a-8722-611bf10c05b5
+      - 727ede35-5569-4ab3-bb86-f32105991ed4
     status: 200 OK
     code: 200
     duration: ""
@@ -548,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -560,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c55ca4f7-fae3-43bb-830d-1393c82d1629
+      - d55af04c-d9e7-4c02-bc20-4ceaef5c0882
     status: 200 OK
     code: 200
     duration: ""
@@ -581,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -593,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96811bea-fa91-4e59-9ad6-e755b4244bc2
+      - 53026747-8168-4be2-8adf-14c861bf9b44
     status: 200 OK
     code: 200
     duration: ""
@@ -614,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -626,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09c5a13a-920a-40a9-9ce5-be3c41040202
+      - 7875b17c-31d4-43b9-ac30-2d002c7b1d05
     status: 200 OK
     code: 200
     duration: ""
@@ -647,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -659,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d85e70a3-f2cf-4d35-8d8f-5d100a1977a7
+      - 61ee217f-090a-4fc1-b19d-934cd436db56
     status: 200 OK
     code: 200
     duration: ""
@@ -680,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -692,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 102676c6-2448-4fc8-8c93-2c9be35da772
+      - a009fa79-3a89-4557-b066-3bba00f4b1b4
     status: 200 OK
     code: 200
     duration: ""
@@ -713,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -725,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6e0d7fe-c798-45b1-b986-2d03839b13dd
+      - 3883c1ab-f894-4327-a129-ae18a2410c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -746,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -758,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5a7a35e-f742-48a7-8ca7-72d49446df19
+      - 83ac2931-29bc-4106-9e11-a587f2befa84
     status: 200 OK
     code: 200
     duration: ""
@@ -779,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["c632a9b3-7f04-49c6-a230-31882d7b31c5","194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "340"
@@ -791,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,12 +832,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5837bf66-c9c8-4dbe-9af8-9248cddae2f7
+      - f01521f1-e2f7-49a6-a26a-62ebe39047ff
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"user_ids":null,"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     form: {}
     headers:
       Content-Type:
@@ -814,10 +845,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals
     method: PUT
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -826,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2973b897-f717-4660-baf0-d828f2f57276
+      - 1fe0f4e5-1a6c-4862-8a4c-49824c859c61
     status: 200 OK
     code: 200
     duration: ""
@@ -849,10 +880,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: PATCH
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -861,7 +892,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90af4441-6524-40ef-9715-96e552054b3b
+      - c9805fbc-be2a-458a-8994-e7f30b88072b
     status: 200 OK
     code: 200
     duration: ""
@@ -882,10 +913,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -894,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4a706f9-1591-4ce2-8ab4-aac4593d6d06
+      - 7a01c75d-5385-4129-a912-fbcc61b73e8c
     status: 200 OK
     code: 200
     duration: ""
@@ -915,10 +946,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -927,7 +958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cab6122-2652-44b5-bd98-0bfe7af6233f
+      - daa4880f-9368-4284-a36e-dd4a53158fed
     status: 200 OK
     code: 200
     duration: ""
@@ -948,43 +979,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "257"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f2429710-5265-4f36-8e8e-f2bf8e221668
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
-    method: GET
-  response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -993,7 +991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77619753-267c-484f-aef5-9b6185cfd9bc
+      - 4422d4cd-4eb1-4dc9-9c93-33b7ae4ea645
     status: 200 OK
     code: 200
     duration: ""
@@ -1014,43 +1012,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
-    headers:
-      Content-Length:
-      - "301"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d36c9053-b944-4e1f-b1a3-243012ec80c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
-    method: GET
-  response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1059,7 +1024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84b4621b-0c03-43f2-a2b5-991918078508
+      - eb02af3a-ce91-4a04-afa3-ac91d7243dcb
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,10 +1045,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 187b1fb9-338a-40cf-a987-775dcf550dd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    method: GET
+  response:
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1092,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1102,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 730456c8-f5b9-4acf-a8d6-d0c7c5c6ba19
+      - 8c632717-2248-4a84-a4a7-04db95d608b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1113,10 +1111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -1125,7 +1123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1135,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f244391e-bcfb-4470-aafc-b3c03c5d7dce
+      - 225945cf-5c00-4613-ae36-fa3e2d54067e
     status: 200 OK
     code: 200
     duration: ""
@@ -1146,10 +1144,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a4c487bc-07c0-413f-854a-b7c61d97bbfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    method: GET
+  response:
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["194d77a7-b295-496f-92b1-4f2fcbe9c84c"]}'
     headers:
       Content-Length:
       - "301"
@@ -1158,7 +1189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1168,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1b8c17d-5fbf-467c-a6a8-fbbfaeb5dee6
+      - 7e5083c9-2957-4869-bf43-78f279e26431
     status: 200 OK
     code: 200
     duration: ""
@@ -1179,10 +1210,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b/principals/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: DELETE
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
     headers:
       Content-Length:
       - "301"
@@ -1191,7 +1222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1201,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f1123d0-5e9b-454d-8711-d544a5cfb9d8
+      - 858cc57d-e0bf-48b7-9c8b-1d3cbb926b9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1214,10 +1245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: PATCH
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1226,7 +1257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1236,7 +1267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 007a15b2-1dd6-46fc-81e8-f91904754185
+      - 28cd5946-7fcd-48e6-8ad9-6972b1fe9a4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1247,10 +1278,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1259,7 +1290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1269,7 +1300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a6e7b27-2de3-4fd4-abee-9589289b35e5
+      - 14dc2914-50d1-45e5-b40e-d36748013659
     status: 200 OK
     code: 200
     duration: ""
@@ -1280,10 +1311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1292,7 +1323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1302,7 +1333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f69a4d73-6b87-475e-97ab-507b18221217
+      - f7903d87-f2ad-4a40-9eb5-de17d68e77a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1313,10 +1344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","name":"first app","description":"","created_at":"2022-06-28T12:20:50.279080Z","updated_at":"2022-06-28T12:20:50.279080Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1325,7 +1356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1335,7 +1366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4877c94f-1597-4a39-81a0-d7efada47836
+      - 3443d953-5f08-475a-a56d-deff54a5bceb
     status: 200 OK
     code: 200
     duration: ""
@@ -1346,43 +1377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fcd2af81-022e-4d61-9cf0-523a34b9067a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
-    method: GET
-  response:
-    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","name":"second app","description":"","created_at":"2022-06-28T12:20:53.333572Z","updated_at":"2022-06-28T12:20:53.333572Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1391,7 +1389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1401,7 +1399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25fbcc81-fcc9-4175-a23b-4d18883549c0
+      - a8819fc3-0f9f-4353-bb89-d87fb9ef4c92
     status: 200 OK
     code: 200
     duration: ""
@@ -1412,103 +1410,136 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9b4325d2-c821-488f-af34-fe8f2cf1909a
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58263fd7-a70e-4b45-903d-d3ce3314f2e4
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b383c113-254c-41f2-ac8f-ae8ec51e8ac4
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","type":"not_found"}'
+    body: '{"id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","created_at":"2022-06-28T12:20:50.437589Z","updated_at":"2022-06-28T12:20:50.437589Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51b73078-0832-4c57-9a97-466651f21763
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5c042e7-43de-4290-8133-c65b59dd1063
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25552ec7-d2af-4c50-afc6-ab8a4b0a48db
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 573e71f5-3182-4e3d-9da6-db5fe0a5e817
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/a28ac2da-6005-4a25-9625-7bae51b62f9b
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"a28ac2da-6005-4a25-9625-7bae51b62f9b","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -1517,7 +1548,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1527,7 +1558,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 011221d3-9957-48d7-a911-f38bcd8d694d
+      - 5fd7cf78-b118-4cf7-9026-eaa68799f90b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1538,10 +1569,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c632a9b3-7f04-49c6-a230-31882d7b31c5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"b3eba34e-8501-4550-800f-ba98a0c784c3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"c632a9b3-7f04-49c6-a230-31882d7b31c5","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1550,7 +1581,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1560,7 +1591,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd95486d-da5f-4103-a8b5-9f770d1013b1
+      - 71e2081f-ff69-4930-ab88-20b292eea607
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1571,10 +1602,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/194d77a7-b295-496f-92b1-4f2fcbe9c84c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"194d77a7-b295-496f-92b1-4f2fcbe9c84c","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1583,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:02 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c67d73a7-1c3e-40fa-b433-ad367051aa2b
+      - 5d42fe43-ff19-48ea-a8b9-221248f7f317
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-applications.cassette.yaml
@@ -1,0 +1,1599 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"first app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications
+    method: POST
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a05a0413-91a0-4762-86d9-5e4923f02388
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6131cdc8-b6e9-4783-ac03-e4e8012fddbc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups
+    method: POST
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe88f1cb-70b4-4d36-839b-38b3aac3220a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":null,"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    method: PUT
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40bafe3f-df0b-4e5b-bcbc-10a47d3f7f81
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6476d897-ac40-40fe-bb32-eeedd420c1e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a8e3d3d7-cccf-4ddd-9b90-7423e42b0ea1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2fb5c91-69c3-4ebd-adb7-9517a21020e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45f23182-647a-4fd6-b0e1-750b777955a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f9e95966-4865-4f47-a7c3-6e313982f003
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6e70289-d9d8-47ee-804c-8e3cf417215d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"second app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications
+    method: POST
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a3d6fa9-61a3-42f2-9c9f-74261ce5f5ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bcde0de0-eee1-4c87-b884-7b2671707aa8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9562cc09-5d8c-4f35-82fd-0c3d8dddfdd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":null,"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    method: PUT
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45f388c2-777e-4d89-90ed-2b5b5deb3688
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: PATCH
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f11b242-d5ee-412b-a142-a8b28430f10a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbc44c46-c634-4d2a-8722-611bf10c05b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c55ca4f7-fae3-43bb-830d-1393c82d1629
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 96811bea-fa91-4e59-9ad6-e755b4244bc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09c5a13a-920a-40a9-9ce5-be3c41040202
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d85e70a3-f2cf-4d35-8d8f-5d100a1977a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 102676c6-2448-4fc8-8c93-2c9be35da772
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6e0d7fe-c798-45b1-b986-2d03839b13dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5a7a35e-f742-48a7-8ca7-72d49446df19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["b3eba34e-8501-4550-800f-ba98a0c784c3","05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5837bf66-c9c8-4dbe-9af8-9248cddae2f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":null,"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals
+    method: PUT
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2973b897-f717-4660-baf0-d828f2f57276
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: PATCH
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90af4441-6524-40ef-9715-96e552054b3b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4a706f9-1591-4ce2-8ab4-aac4593d6d06
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3cab6122-2652-44b5-bd98-0bfe7af6233f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f2429710-5265-4f36-8e8e-f2bf8e221668
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77619753-267c-484f-aef5-9b6185cfd9bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d36c9053-b944-4e1f-b1a3-243012ec80c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 84b4621b-0c03-43f2-a2b5-991918078508
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 730456c8-f5b9-4acf-a8d6-d0c7c5c6ba19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f244391e-bcfb-4470-aafc-b3c03c5d7dce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["05c1a4fa-ce62-4375-8296-c73cda7d429f"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a1b8c17d-5fbf-467c-a6a8-fbbfaeb5dee6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48/principals/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: DELETE
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f1123d0-5e9b-454d-8711-d544a5cfb9d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: PATCH
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 007a15b2-1dd6-46fc-81e8-f91904754185
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a6e7b27-2de3-4fd4-abee-9589289b35e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f69a4d73-6b87-475e-97ab-507b18221217
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"id":"b3eba34e-8501-4550-800f-ba98a0c784c3","name":"first app","description":"","created_at":"2022-06-27T17:14:58.661461Z","updated_at":"2022-06-27T17:14:58.661461Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4877c94f-1597-4a39-81a0-d7efada47836
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","created_at":"2022-06-27T17:14:58.784003Z","updated_at":"2022-06-27T17:14:58.784003Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fcd2af81-022e-4d61-9cf0-523a34b9067a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","name":"second app","description":"","created_at":"2022-06-27T17:14:59.635316Z","updated_at":"2022-06-27T17:14:59.635316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25fbcc81-fcc9-4175-a23b-4d18883549c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b4325d2-c821-488f-af34-fe8f2cf1909a
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58263fd7-a70e-4b45-903d-d3ce3314f2e4
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b383c113-254c-41f2-ac8f-ae8ec51e8ac4
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"59d4ce6f-ab6f-4fe6-807e-dd7e1691cf48","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 011221d3-9957-48d7-a911-f38bcd8d694d
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b3eba34e-8501-4550-800f-ba98a0c784c3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"application","resource_id":"b3eba34e-8501-4550-800f-ba98a0c784c3","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "132"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd95486d-da5f-4103-a8b5-9f770d1013b1
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/05c1a4fa-ce62-4375-8296-c73cda7d429f
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"application","resource_id":"05c1a4fa-ce62-4375-8296-c73cda7d429f","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "132"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c67d73a7-1c3e-40fa-b433-ad367051aa2b
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/scaleway/testdata/iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/iam-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:40.754530Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:45 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebf42980-94fe-4bd9-842b-6790fa762ee9
+      - e66de2a5-d492-4eea-86fc-e968abd78b6d
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:40.754530Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:45 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1211d4c6-09f7-4507-a1a1-4761047c47d4
+      - a60125eb-6fbc-48e4-ad71-512950c41522
     status: 200 OK
     code: 200
     duration: ""
@@ -76,19 +76,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:40.754530Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84bc5018-e23c-4169-87d5-4b34818991db
+      - a18a6799-9ca5-431c-be9a-ba67dc29d4b2
     status: 200 OK
     code: 200
     duration: ""
@@ -109,19 +109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:40.754530Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c761a4-7c76-45b2-923e-a3ef9e2823d0
+      - 27299587-7c3d-428b-97f2-ba4dbb16de25
     status: 200 OK
     code: 200
     duration: ""
@@ -142,19 +142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:45.676990Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--exciting-mclaren","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:40.754530Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--kind-yonath","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "276"
+      - "271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:46 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60357a03-93f1-49c7-b375-85baed8213e0
+      - a1b1a0c5-81b0-4a65-b3cd-f5bc86602293
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: PATCH
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:41.463141Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -200,7 +200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff08a5ee-3872-451e-8a45-5c2276d7ae39
+      - 24c1e5a6-5a81-47d7-bc4f-67b965297c0c
     status: 200 OK
     code: 200
     duration: ""
@@ -211,10 +211,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:41.463141Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b33dd37-4dd3-4527-a6c7-1d8847d8babb
+      - cb193608-af40-4d8f-8a24-4cc58b8862d4
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:41.463141Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -258,7 +258,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:47 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -268,7 +268,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7b5c33e-9f07-480c-a855-549cc128d809
+      - 76ed6fec-2289-4013-bbe7-e28795c942ec
     status: 200 OK
     code: 200
     duration: ""
@@ -279,10 +279,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","created_at":"2022-06-24T19:06:45.676990Z","updated_at":"2022-06-24T19:06:47.108349Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"e9ab8412-c50d-4015-952b-641c3a08117c","created_at":"2022-06-27T09:14:40.754530Z","updated_at":"2022-06-27T09:14:41.463141Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -292,7 +292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a00b8ee4-9f1a-4790-bc5f-bbe1a674d141
+      - 128beec7-d66d-48ea-981f-059a5b768a13
     status: 200 OK
     code: 200
     duration: ""
@@ -313,7 +313,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: DELETE
   response:
     body: ""
@@ -323,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 140f8f82-63a1-45c2-be0c-e7a595cf6365
+      - cda8f4e1-1ba4-48ea-bd44-374a3a00c32e
     status: 204 No Content
     code: 204
     duration: ""
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/d991e89e-50a1-4920-bf2f-6c420fbd04d9
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9ab8412-c50d-4015-952b-641c3a08117c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"d991e89e-50a1-4920-bf2f-6c420fbd04d9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"e9ab8412-c50d-4015-952b-641c3a08117c","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -356,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 24 Jun 2022 19:06:48 GMT
+      - Mon, 27 Jun 2022 09:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4c6a5c8-cf99-4b4c-9aae-44ab73c6a516
+      - 181e00fd-9176-4a22-b365-da3f9306400c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/iam-group-basic.cassette.yaml
@@ -1,0 +1,372 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups
+    method: POST
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6277b33d-f227-4f8e-87e7-17f1d45517ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b812d307-0200-4f94-b471-38dc61833cd6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14559e1d-247b-41e0-ae38-dc6d669d17f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56c8b83e-83e2-47e8-a863-d2ac7bee9861
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:29.387901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--competent-sinoussi","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "278"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7d4da43-5600-42e6-8819-d6e2f7a53c2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_basic","description":"basic description"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: PATCH
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57e78d97-536a-4032-a3d2-0aacf51c1e60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77a2b0c7-b694-4796-b0bd-719b30b3d90f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4628656-bd40-4aa8-a64c-08cacbdcdde1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","created_at":"2022-06-24T14:16:29.387901Z","updated_at":"2022-06-24T14:16:30.054011Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+      description","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "282"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edc880ec-a049-41c0-90ff-489e9b81b031
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54e70ed8-4924-4301-9f9b-1c9218c98c79
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/c86c3b44-8927-4670-9496-1cd7ccb26ff9
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"c86c3b44-8927-4670-9496-1cd7ccb26ff9","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 24 Jun 2022 14:16:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8d56fc5-5ca2-423c-aa8b-8b74ae041de3
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/scaleway/testdata/iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/iam-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c9426a5-5774-4c8f-852e-14e606ed25ad
+      - f62d0afd-2514-4b7b-ae98-6443bf45bf4d
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffa8a7ba-0ecf-4463-9c6f-d7a3d15a2dfd
+      - 8c19f7de-5958-4939-bbd8-eae5de058123
     status: 200 OK
     code: 200
     duration: ""
@@ -76,19 +76,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70f2cc46-e7bc-432f-92aa-05395462f80e
+      - 14ef051c-2078-42c8-ae8d-6dfaa4fa1813
     status: 200 OK
     code: 200
     duration: ""
@@ -109,19 +109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 471b4348-0f78-4d90-bb00-9dd38fc5408c
+      - dcbece07-594e-444d-a2b6-bfbdfcfe9ada
     status: 200 OK
     code: 200
     duration: ""
@@ -142,19 +142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3819a2ef-d762-4eb8-8b88-dadf4a78a278
+      - c04f1d72-ff94-4a8a-95ad-45677ed8f8aa
     status: 200 OK
     code: 200
     duration: ""
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
     body: ""
@@ -183,7 +183,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -195,7 +195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15cd40ea-bd10-461f-afdd-6799a04ddd7d
+      - eb2f67b1-6d62-4c49-9348-2283c73262cf
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -206,19 +206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:32:58.051756Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "274"
+      - "278"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -228,12 +228,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6634d65c-663d-4e88-8c2e-5d961ef7c84d
+      - f92188f5-5180-4fda-85e1-46fe22ac2afb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-group--zealous-galois","description":"basic description"}'
+    body: '{"name":"tf-group--optimistic-hellman","description":"basic description"}'
     form: {}
     headers:
       Content-Type:
@@ -241,20 +241,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: PATCH
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -264,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2276e06-e430-4b96-be4f-ce59910ec6fc
+      - 7d15617c-6714-4d38-87f1-8664d05dd0fb
     status: 200 OK
     code: 200
     duration: ""
@@ -275,20 +275,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a606444-9c1f-4a97-b836-54bde0c7ac24
+      - 61d46984-ee3d-4824-bee4-be8357a4934f
     status: 200 OK
     code: 200
     duration: ""
@@ -309,20 +309,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -332,7 +332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d7d44cd-597a-4b05-8136-f57d0ddf640c
+      - dcfac6db-2d09-45c0-a305-62a00a26401b
     status: 200 OK
     code: 200
     duration: ""
@@ -343,20 +343,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0e1f38e-06eb-4432-906c-551bd9198b3a
+      - 1bf62b38-e09f-44ab-b48a-8de5ef9ea759
     status: 200 OK
     code: 200
     duration: ""
@@ -377,20 +377,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,7 +400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2aa9b356-9757-47f6-9488-b3da2b50d1f1
+      - decefb98-202d-4b1f-b797-9953a9f82ef0
     status: 200 OK
     code: 200
     duration: ""
@@ -411,51 +411,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Envoy-Ratelimited:
-      - "true"
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6148699c-d3b6-4b2d-814e-12dd64602e89
-    status: 429 Too Many Requests
-    code: 429
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
-    method: GET
-  response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:00.833485Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--optimistic-hellman","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "291"
+      - "295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33f60b5b-2805-4533-993b-d3b2e2c4d6a7
+      - 2a0c0484-613c-47d0-8f59-9574cb750116
     status: 200 OK
     code: 200
     duration: ""
@@ -478,10 +447,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: PATCH
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 29 Jun 2022 13:33:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 23e28564-40af-4270-a1cf-809543afa651
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: '{"name":"iam_group_basic","description":"basic description"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
+    method: PATCH
+  response:
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -491,7 +493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -501,7 +503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bed84bbc-32b2-4632-9de3-acbcd831b367
+      - 81349ea6-8298-4712-a65f-31810efc73de
     status: 200 OK
     code: 200
     duration: ""
@@ -512,10 +514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -525,7 +527,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6facacf-20c4-457a-ad8e-ade9c8534170
+      - dcd1102e-6072-4516-8e97-9b5dac292a2f
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +548,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -559,7 +561,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -569,7 +571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32fd0460-bf85-4df1-b9a4-0d1aa19101c4
+      - 9da1f6fc-a0c5-4486-bbcf-bc39f93ddd5e
     status: 200 OK
     code: 200
     duration: ""
@@ -580,10 +582,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -593,7 +595,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e8f9095-9e81-41cb-b005-55688d1c1d4f
+      - 15bd9f90-88f6-438b-a036-ec94f52fbb6e
     status: 200 OK
     code: 200
     duration: ""
@@ -614,10 +616,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -627,7 +629,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -637,7 +639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37be5fe4-2834-457f-bcd5-f7f0fdf0955b
+      - 45f8fef7-158d-4167-92f2-587d84fc43bf
     status: 200 OK
     code: 200
     duration: ""
@@ -648,10 +650,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:03.597808Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -661,7 +663,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -671,7 +673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90826703-c613-4054-9c99-7de25da68a44
+      - 9b59181d-6b67-4ccb-bcea-07b9c251b873
     status: 200 OK
     code: 200
     duration: ""
@@ -684,10 +686,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: PATCH
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:04.577197Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -697,7 +699,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -707,7 +709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80d37e2d-241a-4be9-842e-05bf1c4938f2
+      - e22d6b9e-85e1-464a-8017-8fe47c441c5d
     status: 200 OK
     code: 200
     duration: ""
@@ -718,10 +720,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:04.577197Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -731,7 +733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -741,7 +743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e871ffaf-7c48-44a0-bd9a-d209d9e304b9
+      - 0452ffbe-e7a8-4c2e-9b0f-26521dc35a4b
     status: 200 OK
     code: 200
     duration: ""
@@ -752,10 +754,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:04.577197Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -765,7 +767,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -775,7 +777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c598474-5860-414c-942d-13ddb16c8e48
+      - d3f2cd52-da17-4669-b45c-fed031c0f032
     status: 200 OK
     code: 200
     duration: ""
@@ -786,10 +788,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"49822e26-66a9-47db-b754-96d966a5cb8f","created_at":"2022-06-29T13:32:58.051756Z","updated_at":"2022-06-29T13:33:04.577197Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -799,7 +801,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -809,7 +811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd46f990-f118-4a4c-a812-1131d9480b53
+      - f3ee3035-3ae8-46a6-9011-18574dc138d2
     status: 200 OK
     code: 200
     duration: ""
@@ -820,7 +822,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: DELETE
   response:
     body: ""
@@ -830,7 +832,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -840,7 +842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e4a521b-0e37-47bf-a403-f8f3add742d5
+      - d46fd304-5ee2-492f-990d-0f9c6cce511d
     status: 204 No Content
     code: 204
     duration: ""
@@ -851,10 +853,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/49822e26-66a9-47db-b754-96d966a5cb8f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"49822e26-66a9-47db-b754-96d966a5cb8f","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -863,7 +865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -873,7 +875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 023f7981-d935-4551-8e2c-f05e103b937d
+      - 48e4cee4-019c-4c5e-a149-3a03094d203f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-basic.cassette.yaml
+++ b/scaleway/testdata/iam-group-basic.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,16 +13,16 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 159c92de-ae0a-4c03-9cac-ad799242d36d
+      - 9c9426a5-5774-4c8f-852e-14e606ed25ad
     status: 200 OK
     code: 200
     duration: ""
@@ -43,19 +43,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a2ece2c-c841-409e-ae7f-8fb1ddecfd01
+      - ffa8a7ba-0ecf-4463-9c6f-d7a3d15a2dfd
     status: 200 OK
     code: 200
     duration: ""
@@ -76,19 +76,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0525125e-e4fc-4979-978d-28f0f284905f
+      - 70f2cc46-e7bc-432f-92aa-05395462f80e
     status: 200 OK
     code: 200
     duration: ""
@@ -109,19 +109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4aff21-e334-45f7-906f-6783aad0f31e
+      - 471b4348-0f78-4d90-bb00-9dd38fc5408c
     status: 200 OK
     code: 200
     duration: ""
@@ -142,19 +142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f5adc58-2c87-42d6-9656-2876b854cbcb
+      - 3819a2ef-d762-4eb8-8b88-dadf4a78a278
     status: 200 OK
     code: 200
     duration: ""
@@ -175,19 +175,50 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 15cd40ea-bd10-461f-afdd-6799a04ddd7d
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    method: GET
+  response:
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:50.273804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "274"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,12 +228,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54800b86-b98e-4330-898b-0714b68b0872
+      - 6634d65c-663d-4e88-8c2e-5d961ef7c84d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-group--goofy-banzai","description":"basic description"}'
+    body: '{"name":"tf-group--zealous-galois","description":"basic description"}'
     form: {}
     headers:
       Content-Type:
@@ -210,20 +241,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: PATCH
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -233,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18bad6a1-3043-4013-a80f-2a0aa2136825
+      - c2276e06-e430-4b96-be4f-ce59910ec6fc
     status: 200 OK
     code: 200
     duration: ""
@@ -244,20 +275,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8c03c59-ed90-45a8-ac3a-d4f048a06325
+      - 7a606444-9c1f-4a97-b836-54bde0c7ac24
     status: 200 OK
     code: 200
     duration: ""
@@ -278,20 +309,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -301,7 +332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79984fa-b9e1-4c15-a04b-504930c625ae
+      - 5d7d44cd-597a-4b05-8136-f57d0ddf640c
     status: 200 OK
     code: 200
     duration: ""
@@ -312,20 +343,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c4cac92-62eb-45b9-9a8d-68f54bd9b14e
+      - b0e1f38e-06eb-4432-906c-551bd9198b3a
     status: 200 OK
     code: 200
     duration: ""
@@ -346,20 +377,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -369,7 +400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 386f1769-c59b-4c3a-a32b-5ab59a645b3b
+      - 2aa9b356-9757-47f6-9488-b3da2b50d1f1
     status: 200 OK
     code: 200
     duration: ""
@@ -380,20 +411,51 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6148699c-d3b6-4b2d-814e-12dd64602e89
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
+    method: GET
+  response:
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:53.067740Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--zealous-galois","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -403,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a04aa040-0d38-4a89-91d2-f749a8a2863a
+      - 33f60b5b-2805-4533-993b-d3b2e2c4d6a7
     status: 200 OK
     code: 200
     duration: ""
@@ -416,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: PATCH
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -429,7 +491,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -439,7 +501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6ae766-f1c3-4766-afea-1e251ffda755
+      - bed84bbc-32b2-4632-9de3-acbcd831b367
     status: 200 OK
     code: 200
     duration: ""
@@ -450,10 +512,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -463,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -473,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c10904-6240-4770-b2fe-653281703d82
+      - d6facacf-20c4-457a-ad8e-ade9c8534170
     status: 200 OK
     code: 200
     duration: ""
@@ -484,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -497,7 +559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -507,7 +569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 987b1f64-e541-4584-8c26-e733374e5bb1
+      - 32fd0460-bf85-4df1-b9a4-0d1aa19101c4
     status: 200 OK
     code: 200
     duration: ""
@@ -518,10 +580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -531,7 +593,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -541,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56d1a0e5-b2a8-4538-9584-ae4e66172bab
+      - 3e8f9095-9e81-41cb-b005-55688d1c1d4f
     status: 200 OK
     code: 200
     duration: ""
@@ -552,10 +614,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -565,7 +627,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -575,7 +637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 524ca2e7-3c9d-4b3a-b105-4ab9e5f9a33a
+      - 37be5fe4-2834-457f-bcd5-f7f0fdf0955b
     status: 200 OK
     code: 200
     duration: ""
@@ -586,10 +648,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:55.934877Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
       description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -599,7 +661,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -609,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c0c82d0-7a93-4701-92c5-3d536d3a81a8
+      - 90826703-c613-4054-9c99-7de25da68a44
     status: 200 OK
     code: 200
     duration: ""
@@ -622,10 +684,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: PATCH
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -635,7 +697,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -645,7 +707,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dc77c6b-c846-471f-b95e-8091951f8457
+      - 80d37e2d-241a-4be9-842e-05bf1c4938f2
     status: 200 OK
     code: 200
     duration: ""
@@ -656,10 +718,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -669,7 +731,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -679,7 +741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2a288d3-7187-4c30-ae7e-b3935b803d7c
+      - e871ffaf-7c48-44a0-bd9a-d209d9e304b9
     status: 200 OK
     code: 200
     duration: ""
@@ -690,10 +752,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -703,7 +765,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -713,7 +775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33572f76-99bf-4c0b-adb6-2bd537d4fce4
+      - 3c598474-5860-414c-942d-13ddb16c8e48
     status: 200 OK
     code: 200
     duration: ""
@@ -724,10 +786,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
+    body: '{"id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","created_at":"2022-06-28T12:20:50.273804Z","updated_at":"2022-06-28T12:20:56.661804Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
       is another description","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
@@ -737,7 +799,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -747,7 +809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af7824b-326d-4b5b-a42f-9e453e826256
+      - fd46f990-f118-4a4c-a812-1131d9480b53
     status: 200 OK
     code: 200
     duration: ""
@@ -758,7 +820,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: DELETE
   response:
     body: ""
@@ -768,7 +830,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -778,7 +840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90f1f321-3262-4367-be88-31cae47c0620
+      - 6e4a521b-0e37-47bf-a403-f8f3add742d5
     status: 204 No Content
     code: 204
     duration: ""
@@ -789,10 +851,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/90e7f7ba-7ff9-48ca-8833-ee9a550e3d36
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"960119c5-6d45-49bb-9572-a54ba04bfc36","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"90e7f7ba-7ff9-48ca-8833-ee9a550e3d36","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -801,7 +863,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -811,7 +873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2fbd00a-9347-4771-b79f-6ded2b886262
+      - 023f7981-d935-4551-8e2c-f05e103b937d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
@@ -1,0 +1,1665 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"first app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications
+    method: POST
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c4723e8-f6d7-4537-bcd3-3da7cd6746ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c66611e9-a81f-46cb-8554-7a9bd85219e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups
+    method: POST
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8306f23-22c5-4f37-9526-48205b8807e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    method: PUT
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7da26845-ef2e-44ca-a00c-67ad07a31004
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd98bbe2-7bbf-4aa3-bd1e-86671a016212
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1378c5bb-1210-4701-8d6d-a0a75660d0f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0df08a8b-1404-4545-a64b-b24a4cf5ee96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35341370-3b17-452c-a1cb-1d719ec64835
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 704e0ac7-ab7f-454b-992e-b4fb238b1fac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9392cbc3-6e44-4b2a-a942-02cf4cb62118
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"second app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications
+    method: POST
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9da71df8-9ff0-423d-9f61-6484361e5862
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 442aa95f-020e-4d6d-a8e7-ea4b5a34f16c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    headers:
+      Content-Length:
+      - "339"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2e94c428-506b-474d-a442-7a1e6913436b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":null,"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    method: PUT
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44d011c2-0983-458a-b1fa-9a08f71a8756
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: PATCH
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6ce208d-101c-4604-abac-f24b0c9f3f16
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dece3945-b0b6-4fb8-bc62-7521ead4446c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1dc2cf8-c3c0-496f-9abb-04c3b3ed62d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2494f9c4-e78d-477d-9c04-c9d0073122a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff88bff5-52ad-42c4-91d4-a86c5d4a92bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7a27d00-0f73-4871-8332-aafe51cf9240
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fae8c915-6532-4923-9bdf-2b3ecf22408e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e23744f4-c22c-4199-9d9b-ced6ab89b02a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce677c2b-9527-48b2-8366-3536ef6f031c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 18ca3d86-60dc-4394-aa3b-1d5cb2193a8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    method: PUT
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbe89170-6d26-4c30-8d76-5e6e32762801
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: PATCH
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b36fddd-ac6d-41d8-a559-39d1ee70ac20
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10c70a9a-859a-4c4b-919a-753ae4aa4d49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb9cd57d-fe98-4cce-87e0-143c50bf3dd4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 29750a8c-80bc-419b-9ff6-0f07d794111b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fa4ad87-782d-42f0-8971-ad19d30ac1b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f57eda5-f133-4817-960b-1abd7a24f042
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bb1aee42-db9b-4fcb-a766-43617cc5a412
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1af622c6-9de6-4b44-9d1e-13fbb1307011
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67b89f95-1b86-466c-9dbd-e47746268f2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ccd8956e-d425-4caf-9a5d-7078a7c864af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: DELETE
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ced7c007-6a44-42c7-976f-880bbd8a47db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/29c31dd4-8ea1-4927-82d9-a0620e04773f
+    method: DELETE
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5179bc5-45dc-4815-8702-4b07ec30626b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017
+    method: DELETE
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed3b57b3-ec4e-4db4-997d-d5bc41ad3021
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: PATCH
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 663476df-7439-4f44-93c8-9cfadf712282
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3d49499-351e-49f9-b12f-e8c7d9ecc078
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4fb3dd35-088d-4f4b-bf9c-3c249fade69e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e003d484-c74c-4d97-a840-31271c58cdef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7613d57-1fe9-403f-84ec-619f61b8b074
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e1f6ae9-9e7d-4312-bd88-56c896c00def
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4faf8d3-217a-4dd4-8dec-ed21f6788c21
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06e501d2-96cb-4971-9a03-139444c6a276
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb385e08-d1d1-436c-86c4-82a3f03b0b44
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "126"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0eaccff8-12ce-40d0-9d49-5c1e58bb552c
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"application","resource_id":"aaf18c92-b704-4833-a398-48591168eba3","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "132"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64541a2e-0c52-43c2-a317-cd3b6a923b5f
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"application","resource_id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "132"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 11:37:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 27e8bd50-eb08-43a4-b0a8-5e251e63623a
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f866d58-1e7f-4b97-8459-1aac6a9278a8
+      - 5c5463e5-ade5-46d9-a0ad-2ffc94f5f503
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 485ba463-d049-484f-af9c-d6d1c82d81e7
+      - 00e33121-9155-497d-9183-beab707b9a61
     status: 200 OK
     code: 200
     duration: ""
@@ -81,7 +81,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04780677-9562-4f42-bf1d-e095d343bafc
+      - 16063c09-b6e9-413c-a5a8-8a684a8009ec
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/members
     method: PUT
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 255d3b08-c887-4de4-a52d-49c2c0a8efb6
+      - 74d99af9-1f7d-4727-b87e-f1f05297c3b4
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e070acd-3a77-41c0-8ff7-b9efd0b75e5a
+      - 536dc2c1-883c-4b66-be82-1614e8366315
     status: 200 OK
     code: 200
     duration: ""
@@ -179,10 +179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 994f5e78-35c0-47a2-81fd-fd75c1143434
+      - 72bb8066-ba84-4e9e-a2eb-ec764981c730
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +212,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e70d4e38-ff8d-4417-bad7-720e6723bbae
+      - 1abe3f15-f66d-4ba0-bb64-a105df9045e7
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b966dd9a-d416-425a-9ba6-c1891f5180f0
+      - e8d451c1-d35f-491c-8c96-5de16fa66c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -278,7 +278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
     body: ""
@@ -286,7 +286,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c1b6bb-712e-474e-9f21-5998bf766208
+      - 8456dcf2-ff2c-4a6a-9685-e7735d71324d
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -309,10 +309,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -321,7 +321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d966f95f-183d-4cb3-b9f2-c23ffda9e422
+      - 3238c2b8-c793-401c-9983-679275b29be4
     status: 200 OK
     code: 200
     duration: ""
@@ -342,10 +342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -354,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e417a3a-210b-469b-9efa-ad986d4f3808
+      - 749395c0-e9e2-4324-803a-e2e499068ccb
     status: 200 OK
     code: 200
     duration: ""
@@ -380,7 +380,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 612f8371-b510-4103-ab44-25ad41071b79
+      - 8109cea4-e792-4c37-b285-7157950425e4
     status: 200 OK
     code: 200
     duration: ""
@@ -410,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
     method: GET
   response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5cd9862-ba3f-4fc4-8c8b-b6b28c228190
+      - b0ae3240-49d8-4349-94f7-4736896895b3
     status: 200 OK
     code: 200
     duration: ""
@@ -443,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d"]}'
     headers:
       Content-Length:
       - "339"
@@ -455,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,12 +465,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f25478e9-9b83-4dfd-afac-06fb4b215da4
+      - e7400cea-41f0-4384-b809-6be0420053ad
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"user_ids":null,"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     form: {}
     headers:
       Content-Type:
@@ -478,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/members
     method: PUT
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "340"
@@ -490,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -500,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1eee3a-b639-4a38-9a60-7ac3825e330d
+      - dfa6c1ac-855c-4b66-a1bc-f63e64a41771
     status: 200 OK
     code: 200
     duration: ""
@@ -513,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: PATCH
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "340"
@@ -525,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -535,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca69136e-abf6-4e26-8b27-56abc0118290
+      - 3deb44c9-7c37-445a-88c9-70f1025e6466
     status: 200 OK
     code: 200
     duration: ""
@@ -546,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "340"
@@ -558,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -568,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6e8c12-f55c-44df-a90a-acb04451d0c8
+      - 30d3b3fe-219b-4585-8726-a485eaba3b5d
     status: 200 OK
     code: 200
     duration: ""
@@ -579,10 +579,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 29 Jun 2022 13:33:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf6bc4e4-864c-42b6-a897-d6d92452409d
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "340"
@@ -591,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -601,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18be3737-2f6e-44bb-bbeb-0e28a7e9820e
+      - a7751c4d-2cf1-4246-bbfb-01d1aac2b94f
     status: 200 OK
     code: 200
     duration: ""
@@ -612,43 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
     method: GET
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "256"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1b0eb799-81bb-4dac-b2e3-403842e5274c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
-    method: GET
-  response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -657,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -667,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fde0d43-8861-473e-9db3-50ec1cc5118b
+      - 9fe87eb7-2606-4fd0-8c3a-40cd38d608c7
     status: 200 OK
     code: 200
     duration: ""
@@ -678,43 +676,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
-    headers:
-      Content-Length:
-      - "340"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b98c356-35b2-4d39-83c7-f39e7e02cb58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
-    method: GET
-  response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -723,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -733,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 399da7cb-1a71-434c-8d15-d55826689a4f
+      - 9be4bf8f-0a05-46d0-b405-270c306fc7bc
     status: 200 OK
     code: 200
     duration: ""
@@ -744,10 +709,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8ec52f96-cd15-411c-874a-7e7fe838d263
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
+    method: GET
+  response:
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -756,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -766,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efdb8405-b6a5-421c-bdfe-b1679d9283a8
+      - ecb8466c-2ee1-429d-b77d-2623f03514ac
     status: 200 OK
     code: 200
     duration: ""
@@ -777,19 +775,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "340"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -799,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13dcf329-b57d-467c-9217-5cea38845ff2
+      - ce0b37cc-e188-47f4-9e00-20d6093bb0b2
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +808,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "340"
@@ -822,7 +820,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,12 +830,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebd310ea-a245-444f-a151-08efaf269e3f
+      - 0e1b83d2-1951-454b-84f8-ca9eb05f6383
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["29516c6e-e1ed-4c74-b538-d2125b15494d","c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
+    headers:
+      Content-Length:
+      - "340"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82ce7c6a-23e7-4e10-a819-ca7dceec34de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     form: {}
     headers:
       Content-Type:
@@ -845,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/members
     method: PUT
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "378"
@@ -857,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -867,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e517d5e-c693-4ba8-b275-b102c92eb554
+      - 530845f4-6b45-4459-9b6b-526b0e2d1301
     status: 200 OK
     code: 200
     duration: ""
@@ -880,10 +911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: PATCH
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "378"
@@ -892,7 +923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -902,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d90e5d3a-7e5d-458f-acfd-651f8bdbcd9e
+      - 92d5f5fa-2089-4d6b-9f68-9dbea5ed278e
     status: 200 OK
     code: 200
     duration: ""
@@ -913,10 +944,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "378"
@@ -925,7 +956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -935,7 +966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0695f2d1-1548-488c-bf0f-a2c70b85405e
+      - 79b552fc-c88e-44ab-a108-f6ca09cbeb36
     status: 200 OK
     code: 200
     duration: ""
@@ -946,10 +977,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "378"
@@ -958,7 +989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -968,7 +999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c1bf7cf-adf9-4e46-9f44-dbb7a8bd2486
+      - b854e0e2-6467-4a98-842a-76c2ffe1eabb
     status: 200 OK
     code: 200
     duration: ""
@@ -979,43 +1010,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "257"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5a59f27-7393-4200-84d3-b886b552b042
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
-    method: GET
-  response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1024,7 +1022,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:54 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1034,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17ad07b5-9d09-4aa1-8e4e-3a36e32b22c7
+      - b09b3611-d05c-40cf-a3dd-099772adf666
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,109 +1043,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 413fd258-7e87-4a3d-950b-b5bd617f59aa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
-    method: GET
-  response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c84da09b-1f20-41ab-943c-c7d801910dd8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
-    method: GET
-  response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "256"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 44e67b01-416a-4fbe-9b83-a68d4a2d6817
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
-    method: GET
-  response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1156,7 +1055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1166,7 +1065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02789050-675e-4e9b-838a-ad4d512a791f
+      - 6455df14-5d83-4445-86de-e28baece0369
     status: 200 OK
     code: 200
     duration: ""
@@ -1177,10 +1076,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
     headers:
       Content-Length:
       - "378"
@@ -1189,7 +1088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1199,7 +1098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71b77b4e-f958-4cd7-9144-3cc77fa93e23
+      - a6b05cf7-2e61-46c3-913b-c02814de7c3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1210,19 +1109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
-    method: DELETE
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
+    method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
-      - "378"
+      - "256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1232,7 +1131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4894aa2c-003a-481f-91ba-547afff9f2ab
+      - 69fb8d9b-ae7e-434c-9adb-e33f3b18875c
     status: 200 OK
     code: 200
     duration: ""
@@ -1243,10 +1142,111 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/29c31dd4-8ea1-4927-82d9-a0620e04773f
-    method: DELETE
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 457086cd-e74b-4de0-9d71-ea2f2b63668e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
+    method: GET
+  response:
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee893e3c-8de2-4c6a-a8af-62b2472b56ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 758af7e2-d05a-47a7-8e3d-343765038935
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/members
+    method: PUT
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
     headers:
       Content-Length:
       - "379"
@@ -1255,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1265,40 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 914ffb86-a5a6-4395-a236-91b171401c8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017
-    method: DELETE
-  response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "301"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 904eae00-412f-4755-bff3-5d6080679c4a
+      - 3e0d2aac-20d7-4321-afc7-a574ed0e401b
     status: 200 OK
     code: 200
     duration: ""
@@ -1311,19 +1278,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: PATCH
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "263"
+      - "379"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1333,7 +1300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 172f33cd-a335-4c9f-94fd-561f69caf6c0
+      - 02ff19e3-d7b0-410c-b45e-e99c9745f5e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,19 +1311,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "263"
+      - "379"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1366,7 +1333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b38a3bc0-4810-49ca-94d5-c0805344de94
+      - 95fc443f-e404-430b-a2df-568d4d875924
     status: 200 OK
     code: 200
     duration: ""
@@ -1377,19 +1344,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "263"
+      - "379"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1399,7 +1366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ce4183e-4b63-4839-b22f-eedf69ee732a
+      - b8b531ef-0ffb-4f6a-aa1b-786cf2098f87
     status: 200 OK
     code: 200
     duration: ""
@@ -1410,10 +1377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1422,7 +1389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1432,7 +1399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a49ba03-d678-4f84-96ca-61e0de941e2e
+      - dc982fdb-3c1f-4718-bd54-3a3bc71810c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1443,10 +1410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
     method: GET
   response:
-    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -1455,7 +1422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1465,7 +1432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d37ff2b6-5bbf-4b08-b6bf-a1bd5b35a891
+      - 0ddc9ced-e6cb-4116-a540-d71700405b46
     status: 200 OK
     code: 200
     duration: ""
@@ -1476,10 +1443,282 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6162a2e0-717d-4433-a47b-388e71bcf69b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
+    method: GET
+  response:
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ab6e6a4-1d5f-40a7-9c8a-8d61c7a9d50c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db97aebd-5d0b-4e01-842e-dff8523d638d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
+    method: GET
+  response:
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1cc1ab33-a6ce-4680-9f73-77216e07ba80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["43b0529c-0b85-45a1-bbf6-5a1336b21787","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 560bd23e-3bcb-4d44-9390-a527593a0e0a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_id":"43b0529c-0b85-45a1-bbf6-5a1336b21787"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/remove-member
+    method: POST
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "457"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02bbb56a-0bdf-4200-b71c-50488976dd53
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_id":"0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/remove-member
+    method: POST
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "379"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae318b28-7ca1-41f7-82f5-0006bc99ccab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_id":"ce18cffd-e7c8-47f8-8de8-00e97e50a0d3"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676/remove-member
+    method: POST
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55b46471-5a93-4e37-b44c-25e69735c933
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_app","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: PATCH
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1488,7 +1727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1498,7 +1737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 219c60ee-4efd-48d2-8493-62281d0019bf
+      - 70187ffa-d4c0-4f78-884b-107f4a37667c
     status: 200 OK
     code: 200
     duration: ""
@@ -1509,103 +1748,268 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a640dcf-79fb-4772-8c3f-7c592235ab38
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46f69a85-e68b-490f-a5ab-86a54e9edd1b
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 30758932-f484-4954-9097-ebdca62be72b
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","type":"not_found"}'
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0deed7e7-ef33-4e4b-818f-34e5f14a4f08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8017400c-bc4e-49b5-8396-8587eaa82a1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
+    method: GET
+  response:
+    body: '{"id":"29516c6e-e1ed-4c74-b538-d2125b15494d","name":"third app","description":"","created_at":"2022-06-29T13:32:58.046901Z","updated_at":"2022-06-29T13:32:58.046901Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 88789f00-47ea-4d8a-b92b-db53aeaf5427
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","created_at":"2022-06-29T13:32:58.191875Z","updated_at":"2022-06-29T13:32:58.191875Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61619092-b42a-4969-890f-e2c4de1a324b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
+    method: GET
+  response:
+    body: '{"id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","name":"fourth app","description":"","created_at":"2022-06-29T13:33:01.231677Z","updated_at":"2022-06-29T13:33:01.231677Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00b502a0-c6fe-4d25-bac4-c1ef068ff4a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 384b9456-69e8-4a30-a33b-c8823df03587
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ffc2df7-dc16-44c3-aa2c-8ff0ab10b09b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 29 Jun 2022 13:33:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a2ac335-cb84-48c9-b34e-2c41f444ba60
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e4a12e76-eff0-4a6c-91a1-9800936b3676
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"e4a12e76-eff0-4a6c-91a1-9800936b3676","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -1614,7 +2018,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1624,7 +2028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3c9c81f-83eb-42c5-8a4a-95e986972c7c
+      - 5bc13c33-998a-4195-a3b5-5f4c10621347
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1635,10 +2039,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    url: https://api.scaleway.com/iam/v1alpha1/applications/29516c6e-e1ed-4c74-b538-d2125b15494d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"29516c6e-e1ed-4c74-b538-d2125b15494d","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1647,7 +2051,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1657,7 +2061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e805d81c-9374-4f46-9a63-64b5b5113af0
+      - 6a3869d3-2134-48c0-9cae-c1ebd5338b7c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1668,10 +2072,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    url: https://api.scaleway.com/iam/v1alpha1/applications/c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"c3fa2ad8-7014-4ce9-bfd1-af5d43f5cea4","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1680,7 +2084,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1690,7 +2094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad77dc04-a4ed-4c59-bc19-a449aa91d41a
+      - 2349d0ab-c9e1-4c79-8403-9c59bdaa527f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
+++ b/scaleway/testdata/iam-group-users-and-applications.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"first app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    body: '{"name":"third app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:15 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c4723e8-f6d7-4537-bcd3-3da7cd6746ad
+      - 0f866d58-1e7f-4b97-8459-1aac6a9278a8
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:15 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c66611e9-a81f-46cb-8554-7a9bd85219e7
+      - 485ba463-d049-484f-af9c-d6d1c82d81e7
     status: 200 OK
     code: 200
     duration: ""
@@ -81,7 +81,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:15 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,12 +100,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8306f23-22c5-4f37-9526-48205b8807e5
+      - 04780677-9562-4f42-bf1d-e095d343bafc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     form: {}
     headers:
       Content-Type:
@@ -113,10 +113,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
     method: PUT
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -125,7 +125,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:15 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -135,7 +135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da26845-ef2e-44ca-a00c-67ad07a31004
+      - 255d3b08-c887-4de4-a52d-49c2c0a8efb6
     status: 200 OK
     code: 200
     duration: ""
@@ -146,10 +146,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:15 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd98bbe2-7bbf-4aa3-bd1e-86671a016212
+      - 8e070acd-3a77-41c0-8ff7-b9efd0b75e5a
     status: 200 OK
     code: 200
     duration: ""
@@ -179,10 +179,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -191,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1378c5bb-1210-4701-8d6d-a0a75660d0f9
+      - 994f5e78-35c0-47a2-81fd-fd75c1143434
     status: 200 OK
     code: 200
     duration: ""
@@ -212,10 +212,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -224,7 +224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0df08a8b-1404-4545-a64b-b24a4cf5ee96
+      - e70d4e38-ff8d-4417-bad7-720e6723bbae
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35341370-3b17-452c-a1cb-1d719ec64835
+      - b966dd9a-d416-425a-9ba6-c1891f5180f0
     status: 200 OK
     code: 200
     duration: ""
@@ -278,10 +278,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36c1b6bb-712e-474e-9f21-5998bf766208
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    method: GET
+  response:
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -290,7 +321,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 704e0ac7-ab7f-454b-992e-b4fb238b1fac
+      - d966f95f-183d-4cb3-b9f2-c23ffda9e422
     status: 200 OK
     code: 200
     duration: ""
@@ -311,10 +342,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -323,7 +354,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,12 +364,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9392cbc3-6e44-4b2a-a942-02cf4cb62118
+      - 5e417a3a-210b-469b-9efa-ad986d4f3808
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"second app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
+    body: '{"name":"fourth app","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -349,7 +380,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -358,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9da71df8-9ff0-423d-9f61-6484361e5862
+      - 612f8371-b510-4103-ab44-25ad41071b79
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -391,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 442aa95f-020e-4d6d-a8e7-ea4b5a34f16c
+      - f5cd9862-ba3f-4fc4-8c8b-b6b28c228190
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13"]}'
     headers:
       Content-Length:
       - "339"
@@ -424,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,12 +465,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e94c428-506b-474d-a442-7a1e6913436b
+      - f25478e9-9b83-4dfd-afac-06fb4b215da4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":null,"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"user_ids":null,"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     form: {}
     headers:
       Content-Type:
@@ -447,10 +478,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
     method: PUT
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -459,7 +490,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:16 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -469,7 +500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44d011c2-0983-458a-b1fa-9a08f71a8756
+      - ac1eee3a-b639-4a38-9a60-7ac3825e330d
     status: 200 OK
     code: 200
     duration: ""
@@ -482,10 +513,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: PATCH
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -494,7 +525,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -504,7 +535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6ce208d-101c-4604-abac-f24b0c9f3f16
+      - ca69136e-abf6-4e26-8b27-56abc0118290
     status: 200 OK
     code: 200
     duration: ""
@@ -515,10 +546,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -527,7 +558,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dece3945-b0b6-4fb8-bc62-7521ead4446c
+      - bb6e8c12-f55c-44df-a90a-acb04451d0c8
     status: 200 OK
     code: 200
     duration: ""
@@ -548,10 +579,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -560,7 +591,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1dc2cf8-c3c0-496f-9abb-04c3b3ed62d7
+      - 18be3737-2f6e-44bb-bbeb-0e28a7e9820e
     status: 200 OK
     code: 200
     duration: ""
@@ -581,10 +612,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -593,7 +624,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2494f9c4-e78d-477d-9c04-c9d0073122a4
+      - 1b0eb799-81bb-4dac-b2e3-403842e5274c
     status: 200 OK
     code: 200
     duration: ""
@@ -614,10 +645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -626,7 +657,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff88bff5-52ad-42c4-91d4-a86c5d4a92bd
+      - 8fde0d43-8861-473e-9db3-50ec1cc5118b
     status: 200 OK
     code: 200
     duration: ""
@@ -647,10 +678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -659,7 +690,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +700,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7a27d00-0f73-4871-8332-aafe51cf9240
+      - 4b98c356-35b2-4d39-83c7-f39e7e02cb58
     status: 200 OK
     code: 200
     duration: ""
@@ -680,10 +711,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -692,7 +723,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +733,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae8c915-6532-4923-9bdf-2b3ecf22408e
+      - 399da7cb-1a71-434c-8d15-d55826689a4f
     status: 200 OK
     code: 200
     duration: ""
@@ -713,10 +744,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -725,7 +756,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e23744f4-c22c-4199-9d9b-ced6ab89b02a
+      - efdb8405-b6a5-421c-bdfe-b1679d9283a8
     status: 200 OK
     code: 200
     duration: ""
@@ -746,10 +777,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -758,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -768,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce677c2b-9527-48b2-8366-3536ef6f031c
+      - 13dcf329-b57d-467c-9217-5cea38845ff2
     status: 200 OK
     code: 200
     duration: ""
@@ -779,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["aaf18c92-b704-4833-a398-48591168eba3","b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":["5141cc8d-0d50-42d0-8a47-7aafb5129f13","4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "340"
@@ -791,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -801,12 +832,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18ca3d86-60dc-4394-aa3b-1d5cb2193a8b
+      - ebd310ea-a245-444f-a151-08efaf269e3f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     form: {}
     headers:
       Content-Type:
@@ -814,10 +845,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals
     method: PUT
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -826,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbe89170-6d26-4c30-8d76-5e6e32762801
+      - 5e517d5e-c693-4ba8-b275-b102c92eb554
     status: 200 OK
     code: 200
     duration: ""
@@ -849,10 +880,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: PATCH
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -861,7 +892,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:17 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -871,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b36fddd-ac6d-41d8-a559-39d1ee70ac20
+      - d90e5d3a-7e5d-458f-acfd-651f8bdbcd9e
     status: 200 OK
     code: 200
     duration: ""
@@ -882,10 +913,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -894,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -904,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10c70a9a-859a-4c4b-919a-753ae4aa4d49
+      - 0695f2d1-1548-488c-bf0f-a2c70b85405e
     status: 200 OK
     code: 200
     duration: ""
@@ -915,10 +946,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -927,7 +958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -937,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb9cd57d-fe98-4cce-87e0-143c50bf3dd4
+      - 1c1bf7cf-adf9-4e46-9f44-dbb7a8bd2486
     status: 200 OK
     code: 200
     duration: ""
@@ -948,43 +979,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "256"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 29750a8c-80bc-419b-9ff6-0f07d794111b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
-    method: GET
-  response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "257"
@@ -993,7 +991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1003,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fa4ad87-782d-42f0-8971-ad19d30ac1b0
+      - e5a59f27-7393-4200-84d3-b886b552b042
     status: 200 OK
     code: 200
     duration: ""
@@ -1014,109 +1012,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f57eda5-f133-4817-960b-1abd7a24f042
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
-    method: GET
-  response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "257"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bb1aee42-db9b-4fcb-a766-43617cc5a412
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
-    method: GET
-  response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1af622c6-9de6-4b44-9d1e-13fbb1307011
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
-    method: GET
-  response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1125,7 +1024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1135,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67b89f95-1b86-466c-9dbd-e47746268f2b
+      - 17ad07b5-9d09-4aa1-8e4e-3a36e32b22c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1146,10 +1045,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["b61a8933-1628-47cc-9d2f-c77afaa6a3aa"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -1158,7 +1057,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1168,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccd8956e-d425-4caf-9a5d-7078a7c864af
+      - 413fd258-7e87-4a3d-950b-b5bd617f59aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1179,10 +1078,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
-    method: DELETE
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
     headers:
       Content-Length:
       - "378"
@@ -1191,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1201,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ced7c007-6a44-42c7-976f-880bbd8a47db
+      - c84da09b-1f20-41ab-943c-c7d801910dd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1212,10 +1111,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/29c31dd4-8ea1-4927-82d9-a0620e04773f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    method: GET
+  response:
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44e67b01-416a-4fbe-9b83-a68d4a2d6817
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    method: GET
+  response:
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02789050-675e-4e9b-838a-ad4d512a791f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    method: GET
+  response:
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["4ad85ef4-2471-4e4a-87dc-4f1d3b328df2"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71b77b4e-f958-4cd7-9144-3cc77fa93e23
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: DELETE
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":["00000000-0000-0000-0000-000000000000"]}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4894aa2c-003a-481f-91ba-547afff9f2ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/29c31dd4-8ea1-4927-82d9-a0620e04773f
+    method: DELETE
+  response:
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000","00000000-0000-0000-0000-000000000000","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "379"
@@ -1224,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1234,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5179bc5-45dc-4815-8702-4b07ec30626b
+      - 914ffb86-a5a6-4395-a236-91b171401c8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,10 +1276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c/principals/0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215/principals/0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017
     method: DELETE
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
     headers:
       Content-Length:
       - "301"
@@ -1257,7 +1288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1267,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed3b57b3-ec4e-4db4-997d-d5bc41ad3021
+      - 904eae00-412f-4755-bff3-5d6080679c4a
     status: 200 OK
     code: 200
     duration: ""
@@ -1280,10 +1311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: PATCH
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1292,7 +1323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:18 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1302,7 +1333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 663476df-7439-4f44-93c8-9cfadf712282
+      - 172f33cd-a335-4c9f-94fd-561f69caf6c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1313,10 +1344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1325,7 +1356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1335,7 +1366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3d49499-351e-49f9-b12f-e8c7d9ecc078
+      - b38a3bc0-4810-49ca-94d5-c0805344de94
     status: 200 OK
     code: 200
     duration: ""
@@ -1346,10 +1377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "263"
@@ -1358,7 +1389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1368,7 +1399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fb3dd35-088d-4f4b-bf9c-3c249fade69e
+      - 5ce4183e-4b63-4839-b22f-eedf69ee732a
     status: 200 OK
     code: 200
     duration: ""
@@ -1379,76 +1410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","created_at":"2022-06-28T11:37:15.795227Z","updated_at":"2022-06-28T11:37:15.795227Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e003d484-c74c-4d97-a840-31271c58cdef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
-    method: GET
-  response:
-    body: '{"id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","name":"second app","description":"","created_at":"2022-06-28T11:37:16.732880Z","updated_at":"2022-06-28T11:37:16.732880Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
-    headers:
-      Content-Length:
-      - "257"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7613d57-1fe9-403f-84ec-619f61b8b074
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
-    method: GET
-  response:
-    body: '{"id":"aaf18c92-b704-4833-a398-48591168eba3","name":"first app","description":"","created_at":"2022-06-28T11:37:15.671219Z","updated_at":"2022-06-28T11:37:15.671219Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    body: '{"id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","name":"third app","description":"","created_at":"2022-06-28T12:20:50.274408Z","updated_at":"2022-06-28T12:20:50.274408Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
     headers:
       Content-Length:
       - "256"
@@ -1457,7 +1422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1467,7 +1432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e1f6ae9-9e7d-4312-bd88-56c896c00def
+      - 8a49ba03-d678-4f84-96ca-61e0de941e2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1478,103 +1443,169 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f4faf8d3-217a-4dd4-8dec-ed21f6788c21
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06e501d2-96cb-4971-9a03-139444c6a276
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb385e08-d1d1-436c-86c4-82a3f03b0b44
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/8fb104c0-1922-4ffc-ab3c-107bc8d4c89c
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"8fb104c0-1922-4ffc-ab3c-107bc8d4c89c","type":"not_found"}'
+    body: '{"id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","name":"fourth app","description":"","created_at":"2022-06-28T12:20:53.350952Z","updated_at":"2022-06-28T12:20:53.350952Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","editable":true,"nb_api_keys":0}'
+    headers:
+      Content-Length:
+      - "257"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d37ff2b6-5bbf-4b08-b6bf-a1bd5b35a891
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    method: GET
+  response:
+    body: '{"id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","created_at":"2022-06-28T12:20:50.435312Z","updated_at":"2022-06-28T12:20:50.435312Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_app","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "263"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 219c60ee-4efd-48d2-8493-62281d0019bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a640dcf-79fb-4772-8c3f-7c592235ab38
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46f69a85-e68b-490f-a5ab-86a54e9edd1b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 28 Jun 2022 12:20:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30758932-f484-4954-9097-ebdca62be72b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/fc0c7864-0bda-4305-8ee0-4b9a3395a215
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"group","resource_id":"fc0c7864-0bda-4305-8ee0-4b9a3395a215","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -1583,7 +1614,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1593,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eaccff8-12ce-40d0-9d49-5c1e58bb552c
+      - f3c9c81f-83eb-42c5-8a4a-95e986972c7c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1604,10 +1635,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/aaf18c92-b704-4833-a398-48591168eba3
+    url: https://api.scaleway.com/iam/v1alpha1/applications/5141cc8d-0d50-42d0-8a47-7aafb5129f13
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"aaf18c92-b704-4833-a398-48591168eba3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"5141cc8d-0d50-42d0-8a47-7aafb5129f13","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1616,7 +1647,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1626,7 +1657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64541a2e-0c52-43c2-a317-cd3b6a923b5f
+      - e805d81c-9374-4f46-9a63-64b5b5113af0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1637,10 +1668,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/b61a8933-1628-47cc-9d2f-c77afaa6a3aa
+    url: https://api.scaleway.com/iam/v1alpha1/applications/4ad85ef4-2471-4e4a-87dc-4f1d3b328df2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"application","resource_id":"b61a8933-1628-47cc-9d2f-c77afaa6a3aa","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"application","resource_id":"4ad85ef4-2471-4e4a-87dc-4f1d3b328df2","type":"not_found"}'
     headers:
       Content-Length:
       - "132"
@@ -1649,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 11:37:19 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1659,7 +1690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27e8bd50-eb08-43a4-b0a8-5e251e63623a
+      - ad77dc04-a4ed-4c59-bc19-a449aa91d41a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-users.cassette.yaml
+++ b/scaleway/testdata/iam-group-users.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":""}'
+    body: '{"organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,10 +13,10 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -32,24 +32,26 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 159c92de-ae0a-4c03-9cac-ad799242d36d
+      - 5cecd65b-071a-41bd-a6e3-a017f6b9b310
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":null}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: GET
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    method: PUT
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -65,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a2ece2c-c841-409e-ae7f-8fb1ddecfd01
+      - 3c648ec8-3389-4af0-984b-ff0717c63cad
     status: 200 OK
     code: 200
     duration: ""
@@ -76,13 +78,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -98,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0525125e-e4fc-4979-978d-28f0f284905f
+      - 6c3b3a26-9b1f-49a1-98d1-0cf79b0148c0
     status: 200 OK
     code: 200
     duration: ""
@@ -109,13 +111,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -131,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4aff21-e334-45f7-906f-6783aad0f31e
+      - 73462204-1145-4134-a586-03daf7fa2d99
     status: 200 OK
     code: 200
     duration: ""
@@ -142,13 +144,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -164,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f5adc58-2c87-42d6-9656-2876b854cbcb
+      - 9096d429-d842-4a41-8d97-f28239a41537
     status: 200 OK
     code: 200
     duration: ""
@@ -175,13 +177,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:58.656234Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "272"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -197,12 +199,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54800b86-b98e-4330-898b-0714b68b0872
+      - 77804a0f-4229-48f0-b98e-0dc91205293d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-group--goofy-banzai","description":"basic description"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: GET
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "302"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54ddc2fe-8532-4acb-8f0d-4fbeeabefef9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":null}'
     form: {}
     headers:
       Content-Type:
@@ -210,14 +245,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    method: PUT
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "341"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:14:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79657e14-7fae-4da9-8f7d-27a376a6f2a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_user","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: PATCH
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -233,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18bad6a1-3043-4013-a80f-2a0aa2136825
+      - 52958053-3ee7-46a1-8978-8bcb2d2dfd06
     status: 200 OK
     code: 200
     duration: ""
@@ -244,14 +313,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -267,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8c03c59-ed90-45a8-ac3a-d4f048a06325
+      - ce92ac0b-72f1-4e03-9eff-3b08d1d0469b
     status: 200 OK
     code: 200
     duration: ""
@@ -278,14 +346,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -301,7 +368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79984fa-b9e1-4c15-a04b-504930c625ae
+      - fcfffd34-ae47-47e7-affb-d6c87e76a494
     status: 200 OK
     code: 200
     duration: ""
@@ -312,14 +379,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -335,7 +401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c4cac92-62eb-45b9-9a8d-68f54bd9b14e
+      - bdb99f2f-1cd7-4659-8df2-466725f6704a
     status: 200 OK
     code: 200
     duration: ""
@@ -346,48 +412,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "289"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 386f1769-c59b-4c3a-a32b-5ab59a645b3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: GET
-  response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:14:59.404221Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"tf-group--goofy-banzai","description":"basic
-      description","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "289"
+      - "341"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -403,12 +434,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a04aa040-0d38-4a89-91d2-f749a8a2863a
+      - c7b1845d-6ded-41a7-92f4-013b3a69831b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"iam_group_basic","description":"basic description"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: GET
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "341"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86c5bb76-9f82-4865-8838-950f297ac803
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":null}'
     form: {}
     headers:
       Content-Type:
@@ -416,14 +480,48 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    method: PUT
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "302"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07fd03cb-d446-408a-a841-daa09687a719
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_user","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: PATCH
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -439,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6ae766-f1c3-4766-afea-1e251ffda755
+      - 44ccd45a-b299-41ff-ae58-9565c5bfda16
     status: 200 OK
     code: 200
     duration: ""
@@ -450,14 +548,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -473,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c10904-6240-4770-b2fe-653281703d82
+      - 88cf43e6-cc6e-48c9-99e8-a3a0b7c9f4fb
     status: 200 OK
     code: 200
     duration: ""
@@ -484,14 +581,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -507,7 +603,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 987b1f64-e541-4584-8c26-e733374e5bb1
+      - cf1638bd-0835-45f6-9273-bd29fa808c31
     status: 200 OK
     code: 200
     duration: ""
@@ -518,14 +614,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -541,7 +636,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56d1a0e5-b2a8-4538-9584-ae4e66172bab
+      - ffb7fe3b-5d4f-4a13-aee0-4e3277d9f17e
     status: 200 OK
     code: 200
     duration: ""
@@ -552,14 +647,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -575,7 +669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 524ca2e7-3c9d-4b3a-b105-4ab9e5f9a33a
+      - b3c4b9e5-5227-470d-9d5c-970be5b7cf8e
     status: 200 OK
     code: 200
     duration: ""
@@ -586,14 +680,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.090748Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_basic","description":"basic
-      description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "282"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -609,43 +702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c0c82d0-7a93-4701-92c5-3d536d3a81a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"iam_group_renamed","description":"this is another description"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: PATCH
-  response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
-      is another description","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "294"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9dc77c6b-c846-471f-b95e-8091951f8457
+      - d2346e8e-28cc-4eb0-a805-a4ca382028be
     status: 200 OK
     code: 200
     duration: ""
@@ -656,82 +713,13 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: GET
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals/453c1a85-4a10-4c6f-94dc-d3193d4589a5
+    method: DELETE
   response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
-      is another description","user_ids":[],"application_ids":[]}'
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
     headers:
       Content-Length:
-      - "294"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2a288d3-7187-4c30-ae7e-b3935b803d7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: GET
-  response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
-      is another description","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "294"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33572f76-99bf-4c0b-adb6-2bd537d4fce4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
-    method: GET
-  response:
-    body: '{"id":"960119c5-6d45-49bb-9572-a54ba04bfc36","created_at":"2022-06-27T17:14:58.656234Z","updated_at":"2022-06-27T17:15:00.805931Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_renamed","description":"this
-      is another description","user_ids":[],"application_ids":[]}'
-    headers:
-      Content-Length:
-      - "294"
+      - "302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
@@ -747,7 +735,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af7824b-326d-4b5b-a42f-9e453e826256
+      - 87764e88-9ba6-41d3-abad-7d2fecea8761
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"iam_group_user","description":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: PATCH
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a6b885a-3053-4de7-b893-8061c624db57
     status: 200 OK
     code: 200
     duration: ""
@@ -758,7 +781,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: GET
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9dafcb1-0122-46f4-a614-15b713ac7304
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: GET
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff9074d9-fe5d-46eb-9f3a-d7ba844baf49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    method: GET
+  response:
+    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    headers:
+      Content-Length:
+      - "264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 27 Jun 2022 17:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06e0ad33-035d-4756-a5da-07322459bf64
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: DELETE
   response:
     body: ""
@@ -778,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90f1f321-3262-4367-be88-31cae47c0620
+      - eb7be9a6-f087-4a71-a8cb-b687bfd70547
     status: 204 No Content
     code: 204
     duration: ""
@@ -789,10 +911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/960119c5-6d45-49bb-9572-a54ba04bfc36
+    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"960119c5-6d45-49bb-9572-a54ba04bfc36","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -811,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2fbd00a-9347-4771-b79f-6ded2b886262
+      - e8d1fe9d-1fe0-4564-a002-537510c5e750
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-users.cassette.yaml
+++ b/scaleway/testdata/iam-group-users.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cecd65b-071a-41bd-a6e3-a017f6b9b310
+      - be1874f0-a7b4-44ba-b0f6-2f8a321a0049
     status: 200 OK
     code: 200
     duration: ""
@@ -45,10 +45,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
     method: PUT
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -57,7 +57,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c648ec8-3389-4af0-984b-ff0717c63cad
+      - 10380e6a-d515-4ef2-9e4d-24279678d488
     status: 200 OK
     code: 200
     duration: ""
@@ -78,10 +78,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c3b3a26-9b1f-49a1-98d1-0cf79b0148c0
+      - a117bb09-e0fd-47e6-885a-9e7651fd8fdf
     status: 200 OK
     code: 200
     duration: ""
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -123,7 +123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:58 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73462204-1145-4134-a586-03daf7fa2d99
+      - 26bf2e6a-22c9-4fc3-990d-d44195788576
     status: 200 OK
     code: 200
     duration: ""
@@ -144,10 +144,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -156,7 +156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9096d429-d842-4a41-8d97-f28239a41537
+      - 41dd0c8b-70f9-49b2-b954-e63c470bc429
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +177,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 75b0b924-3214-4ee4-9c75-4b7aeec9421b
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    method: GET
+  response:
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -189,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77804a0f-4229-48f0-b98e-0dc91205293d
+      - a2febe42-774b-48a3-9514-8b54e2be5771
     status: 200 OK
     code: 200
     duration: ""
@@ -210,10 +241,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -222,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54ddc2fe-8532-4acb-8f0d-4fbeeabefef9
+      - 6b502237-50e4-4c4f-be98-006f5e70295f
     status: 200 OK
     code: 200
     duration: ""
@@ -245,10 +276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
     method: PUT
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -257,7 +288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79657e14-7fae-4da9-8f7d-27a376a6f2a3
+      - 1c9619db-69ff-410a-af15-80f82200c7b4
     status: 200 OK
     code: 200
     duration: ""
@@ -280,10 +311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: PATCH
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -292,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -302,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52958053-3ee7-46a1-8978-8bcb2d2dfd06
+      - 57bb4eb9-0370-41fb-acb8-68529da54dff
     status: 200 OK
     code: 200
     duration: ""
@@ -313,10 +344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -325,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -335,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce92ac0b-72f1-4e03-9eff-3b08d1d0469b
+      - 68580d89-88dd-4a5a-9ef0-a755f011114a
     status: 200 OK
     code: 200
     duration: ""
@@ -346,10 +377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -358,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -368,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcfffd34-ae47-47e7-affb-d6c87e76a494
+      - 77f3959b-826a-4bac-bcb0-5abef0aa8ad6
     status: 200 OK
     code: 200
     duration: ""
@@ -379,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -391,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:14:59 GMT
+      - Tue, 28 Jun 2022 12:20:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -401,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdb99f2f-1cd7-4659-8df2-466725f6704a
+      - 129978e9-1809-4b0d-b694-b736a5820b85
     status: 200 OK
     code: 200
     duration: ""
@@ -412,10 +443,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Tue, 28 Jun 2022 12:20:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Envoy-Ratelimited:
+      - "true"
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f185b3ea-5209-400e-afd2-c177aa739ccf
+    status: 429 Too Many Requests
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    method: GET
+  response:
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -424,7 +486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -434,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7b1845d-6ded-41a7-92f4-013b3a69831b
+      - 81ac1d19-40d2-4e69-81ec-7baaf8880d88
     status: 200 OK
     code: 200
     duration: ""
@@ -445,10 +507,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -457,7 +519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -467,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86c5bb76-9f82-4865-8838-950f297ac803
+      - e5bf2192-3e97-4590-9268-f7dc4f7af63e
     status: 200 OK
     code: 200
     duration: ""
@@ -480,10 +542,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
     method: PUT
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -492,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -502,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07fd03cb-d446-408a-a841-daa09687a719
+      - a0e44b6d-d999-497f-bd53-32ad7fbd790b
     status: 200 OK
     code: 200
     duration: ""
@@ -515,10 +577,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: PATCH
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -527,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -537,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44ccd45a-b299-41ff-ae58-9565c5bfda16
+      - a5857f17-720c-48da-8ec5-a46c8107ef50
     status: 200 OK
     code: 200
     duration: ""
@@ -548,10 +610,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -560,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -570,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88cf43e6-cc6e-48c9-99e8-a3a0b7c9f4fb
+      - 7c5b8501-5fb1-4554-9f4c-560266133207
     status: 200 OK
     code: 200
     duration: ""
@@ -581,10 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -593,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -603,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf1638bd-0835-45f6-9273-bd29fa808c31
+      - eae5abfa-9128-4003-ab8b-b8fbd8beec45
     status: 200 OK
     code: 200
     duration: ""
@@ -614,10 +676,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -626,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -636,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb7fe3b-5d4f-4a13-aee0-4e3277d9f17e
+      - a2ccae67-3084-4bb5-bc7a-81c10125327b
     status: 200 OK
     code: 200
     duration: ""
@@ -647,10 +709,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -659,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -669,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3c4b9e5-5227-470d-9d5c-970be5b7cf8e
+      - 84f46779-f58d-4d45-99e0-598fd21a6022
     status: 200 OK
     code: 200
     duration: ""
@@ -680,10 +742,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -692,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:00 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -702,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2346e8e-28cc-4eb0-a805-a4ca382028be
+      - 9ecd14e2-0dfa-4a9f-a2d1-d3add4fb96a6
     status: 200 OK
     code: 200
     duration: ""
@@ -713,10 +775,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630/principals/453c1a85-4a10-4c6f-94dc-d3193d4589a5
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals/453c1a85-4a10-4c6f-94dc-d3193d4589a5
     method: DELETE
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -725,7 +787,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -735,7 +797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87764e88-9ba6-41d3-abad-7d2fecea8761
+      - 1ba60397-b88b-4488-8dc3-a79924442dfb
     status: 200 OK
     code: 200
     duration: ""
@@ -748,10 +810,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: PATCH
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -760,7 +822,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -770,7 +832,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a6b885a-3053-4de7-b893-8061c624db57
+      - 7c159898-3aa9-450f-bb88-47fa33575cf5
     status: 200 OK
     code: 200
     duration: ""
@@ -781,10 +843,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -793,7 +855,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -803,7 +865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9dafcb1-0122-46f4-a614-15b713ac7304
+      - ee21d326-2047-4edf-a6ca-4dbcaf962939
     status: 200 OK
     code: 200
     duration: ""
@@ -814,10 +876,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -826,7 +888,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -836,7 +898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff9074d9-fe5d-46eb-9f3a-d7ba844baf49
+      - c478ac35-5a40-48ce-bdd4-c079168e07c5
     status: 200 OK
     code: 200
     duration: ""
@@ -847,10 +909,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","created_at":"2022-06-27T17:14:58.656316Z","updated_at":"2022-06-27T17:14:58.656316Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -859,7 +921,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -869,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06e0ad33-035d-4756-a5da-07322459bf64
+      - 308b56b2-3946-4858-b5d0-1325e0a8985a
     status: 200 OK
     code: 200
     duration: ""
@@ -880,7 +942,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: DELETE
   response:
     body: ""
@@ -890,7 +952,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -900,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb7be9a6-f087-4a71-a8cb-b687bfd70547
+      - 424a5a89-1bff-4e71-916e-9e7da835ae92
     status: 204 No Content
     code: 204
     duration: ""
@@ -911,10 +973,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/3f3517d2-fa16-4a3f-b708-89efa85a4630
+    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"3f3517d2-fa16-4a3f-b708-89efa85a4630","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -923,7 +985,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 27 Jun 2022 17:15:01 GMT
+      - Tue, 28 Jun 2022 12:20:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -933,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8d1fe9d-1fe0-4564-a002-537510c5e750
+      - 6f59a7c6-5790-4d23-95f5-a8f3583b98a5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iam-group-users.cassette.yaml
+++ b/scaleway/testdata/iam-group-users.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/groups
     method: POST
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be1874f0-a7b4-44ba-b0f6-2f8a321a0049
+      - 041df9fa-f4dc-477e-bb9d-556f1a19be2f
     status: 200 OK
     code: 200
     duration: ""
@@ -45,10 +45,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e/members
     method: PUT
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -57,7 +57,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10380e6a-d515-4ef2-9e4d-24279678d488
+      - d936d67c-405d-4d43-ab04-84ddfc78babb
     status: 200 OK
     code: 200
     duration: ""
@@ -78,10 +78,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a117bb09-e0fd-47e6-885a-9e7651fd8fdf
+      - f45068d2-b1f5-415e-84c6-fddf1f14b46d
     status: 200 OK
     code: 200
     duration: ""
@@ -111,10 +111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -123,7 +123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26bf2e6a-22c9-4fc3-990d-d44195788576
+      - c71281c9-9175-4669-9c10-670c896fdabf
     status: 200 OK
     code: 200
     duration: ""
@@ -144,10 +144,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -156,7 +156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41dd0c8b-70f9-49b2-b954-e63c470bc429
+      - 7bc25c59-42fb-41cb-8d7b-920a64250cc8
     status: 200 OK
     code: 200
     duration: ""
@@ -177,7 +177,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
     body: ""
@@ -185,7 +185,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:50 GMT
+      - Wed, 29 Jun 2022 13:32:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -197,7 +197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75b0b924-3214-4ee4-9c75-4b7aeec9421b
+      - 1e6120ec-c4a9-4ac9-a8b3-61009d2d2fbd
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -208,10 +208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -220,7 +220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:52 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -230,7 +230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2febe42-774b-48a3-9514-8b54e2be5771
+      - b982fdd4-67d2-4819-965e-ab3dc58575f0
     status: 200 OK
     code: 200
     duration: ""
@@ -241,10 +241,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -263,7 +263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b502237-50e4-4c4f-be98-006f5e70295f
+      - 2d5c7095-3d19-46bd-afe2-5e42823a5381
     status: 200 OK
     code: 200
     duration: ""
@@ -276,10 +276,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e/members
     method: PUT
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -288,7 +288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c9619db-69ff-410a-af15-80f82200c7b4
+      - 3c971884-f1e4-4c29-b6e2-c41373198939
     status: 200 OK
     code: 200
     duration: ""
@@ -311,10 +311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: PATCH
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -323,7 +323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57bb4eb9-0370-41fb-acb8-68529da54dff
+      - 4e8783c1-ead7-4726-a751-2443ca0f9935
     status: 200 OK
     code: 200
     duration: ""
@@ -344,10 +344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -356,7 +356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68580d89-88dd-4a5a-9ef0-a755f011114a
+      - f76c6736-f6a6-42c0-9acc-252aae79560b
     status: 200 OK
     code: 200
     duration: ""
@@ -377,10 +377,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -389,7 +389,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77f3959b-826a-4bac-bcb0-5abef0aa8ad6
+      - 06e1d87a-8c09-4fc4-a1b2-a614754d0a86
     status: 200 OK
     code: 200
     duration: ""
@@ -410,10 +410,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 129978e9-1809-4b0d-b694-b736a5820b85
+      - b2f48af5-c01d-4f25-a7cb-fb7024940b82
     status: 200 OK
     code: 200
     duration: ""
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
     body: ""
@@ -451,7 +451,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 28 Jun 2022 12:20:53 GMT
+      - Wed, 29 Jun 2022 13:33:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -463,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f185b3ea-5209-400e-afd2-c177aa739ccf
+      - c1dd08b1-878e-40a5-bf36-7275224f2441
     status: 429 Too Many Requests
     code: 429
     duration: ""
@@ -474,10 +474,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -486,7 +486,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:55 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -496,7 +496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81ac1d19-40d2-4e69-81ec-7baaf8880d88
+      - 5bb92628-db7d-47a2-a849-a49ffff2fcec
     status: 200 OK
     code: 200
     duration: ""
@@ -507,10 +507,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["29c31dd4-8ea1-4927-82d9-a0620e04773f","0afd8f94-eaf1-4949-9dcb-9ae5f4bc1017"],"application_ids":[]}'
     headers:
       Content-Length:
       - "341"
@@ -519,7 +519,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -529,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5bf2192-3e97-4590-9268-f7dc4f7af63e
+      - 053065f0-2c2e-4808-98ff-cd44203fc859
     status: 200 OK
     code: 200
     duration: ""
@@ -542,10 +542,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e/members
     method: PUT
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -554,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0e44b6d-d999-497f-bd53-32ad7fbd790b
+      - 47ba0add-97e7-4fa8-b246-f3e36ec08ad9
     status: 200 OK
     code: 200
     duration: ""
@@ -577,10 +577,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: PATCH
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -589,7 +589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -599,7 +599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5857f17-720c-48da-8ec5-a46c8107ef50
+      - a7ff91d0-6407-4347-be7e-bd94f5486c16
     status: 200 OK
     code: 200
     duration: ""
@@ -610,10 +610,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -622,7 +622,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -632,7 +632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c5b8501-5fb1-4554-9f4c-560266133207
+      - 9898f15c-5f69-4cdb-bd28-4944802a1fc5
     status: 200 OK
     code: 200
     duration: ""
@@ -643,10 +643,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -655,7 +655,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -665,7 +665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae5abfa-9128-4003-ab8b-b8fbd8beec45
+      - 424bcdc9-a36e-4217-b4ad-8c4b7bca45d4
     status: 200 OK
     code: 200
     duration: ""
@@ -676,10 +676,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -688,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -698,7 +698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2ccae67-3084-4bb5-bc7a-81c10125327b
+      - 9fd2caf6-eb2d-4535-8a7a-137320a9dcb3
     status: 200 OK
     code: 200
     duration: ""
@@ -709,10 +709,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -721,7 +721,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -731,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84f46779-f58d-4d45-99e0-598fd21a6022
+      - def83240-8d04-43a4-8d4e-c9279c0e3493
     status: 200 OK
     code: 200
     duration: ""
@@ -742,10 +742,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["453c1a85-4a10-4c6f-94dc-d3193d4589a5"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -754,7 +754,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -764,21 +764,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ecd14e2-0dfa-4a9f-a2d1-d3add4fb96a6
+      - 9c1ab2ff-3e74-4059-b6ed-4bbd247b096a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"user_id":"453c1a85-4a10-4c6f-94dc-d3193d4589a5"}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc/principals/453c1a85-4a10-4c6f-94dc-d3193d4589a5
-    method: DELETE
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e/remove-member
+    method: POST
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":["00000000-0000-0000-0000-000000000000"],"application_ids":[]}'
     headers:
       Content-Length:
       - "302"
@@ -787,7 +789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -797,7 +799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ba60397-b88b-4488-8dc3-a79924442dfb
+      - 73bf52a6-db2b-41cb-8619-6b5607f28983
     status: 200 OK
     code: 200
     duration: ""
@@ -810,10 +812,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: PATCH
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -832,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c159898-3aa9-450f-bb88-47fa33575cf5
+      - 3fdba12d-210c-4e3b-a702-c72062052103
     status: 200 OK
     code: 200
     duration: ""
@@ -843,10 +845,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -855,7 +857,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:56 GMT
+      - Wed, 29 Jun 2022 13:33:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -865,7 +867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee21d326-2047-4edf-a6ca-4dbcaf962939
+      - 33a12bd5-7e20-4b4d-a22e-d09e1644dda0
     status: 200 OK
     code: 200
     duration: ""
@@ -876,10 +878,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -888,7 +890,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c478ac35-5a40-48ce-bdd4-c079168e07c5
+      - fe328931-9613-4282-b111-685fed003176
     status: 200 OK
     code: 200
     duration: ""
@@ -909,10 +911,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","created_at":"2022-06-28T12:20:50.280494Z","updated_at":"2022-06-28T12:20:50.280494Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
+    body: '{"id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","created_at":"2022-06-29T13:32:58.074786Z","updated_at":"2022-06-29T13:32:58.074786Z","organization_id":"08555df8-bb26-43bc-b749-1b98c5d02343","name":"iam_group_user","description":"","user_ids":[],"application_ids":[]}'
     headers:
       Content-Length:
       - "264"
@@ -921,7 +923,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 308b56b2-3946-4858-b5d0-1325e0a8985a
+      - 4aa85929-8e86-47ff-8ed6-60695b8802a8
     status: 200 OK
     code: 200
     duration: ""
@@ -942,7 +944,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: DELETE
   response:
     body: ""
@@ -952,7 +954,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -962,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 424a5a89-1bff-4e71-916e-9e7da835ae92
+      - 3591ea46-6663-4f17-87f1-8a2179cb1602
     status: 204 No Content
     code: 204
     duration: ""
@@ -973,10 +975,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.18.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/groups/e9f80489-07e9-4e68-b5fa-47918e743dbc
+    url: https://api.scaleway.com/iam/v1alpha1/groups/0685a966-c156-4c16-aa42-5b7d8d00e26e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"group","resource_id":"e9f80489-07e9-4e68-b5fa-47918e743dbc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"group","resource_id":"0685a966-c156-4c16-aa42-5b7d8d00e26e","type":"not_found"}'
     headers:
       Content-Length:
       - "126"
@@ -985,7 +987,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 28 Jun 2022 12:20:57 GMT
+      - Wed, 29 Jun 2022 13:33:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -995,7 +997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f59a7c6-5790-4d23-95f5-a8f3583b98a5
+      - f0034b5d-a356-462f-80c8-6f88f8020af7
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
I managed to keep things the way they worked before the breaking changes of the IAM API, all my tests with users. applications and both at the same time work fine without these attributes being required, I think it's more user-friendly this way.